### PR TITLE
Change `fromServiceInfo` return value to ServiceInstance

### DIFF
--- a/src/main/java/org/kiwiproject/registry/model/ServiceInstance.java
+++ b/src/main/java/org/kiwiproject/registry/model/ServiceInstance.java
@@ -2,6 +2,7 @@ package org.kiwiproject.registry.model;
 
 import lombok.Builder;
 import lombok.Getter;
+import lombok.With;
 import org.kiwiproject.registry.config.ServiceInfo;
 
 import java.util.List;
@@ -22,13 +23,17 @@ public class ServiceInstance {
         STARTING
     }
 
+    @With
     protected final String instanceId;
+
+    @With
+    protected final Status status;
+
     protected final String serviceName;
     protected final String hostName;
     protected final String ip;
     protected final List<Port> ports;
     protected final ServicePaths paths;
-    protected final Status status;
     protected final String commitRef;
     protected final String description;
     protected final String version;
@@ -39,7 +44,7 @@ public class ServiceInstance {
      * @param serviceInfo The information about the service used to initialize the {@code ServiceInstanceBuilder}
      * @return a {@code ServiceInstanceBuilder} with values copied from the given {@link ServiceInfo}
      */
-    public static ServiceInstanceBuilder fromServiceInfo(ServiceInfo serviceInfo) {
+    public static ServiceInstance fromServiceInfo(ServiceInfo serviceInfo) {
         return ServiceInstance.builder()
                 .serviceName(serviceInfo.getName())
                 .hostName(serviceInfo.getHostname())
@@ -48,7 +53,8 @@ public class ServiceInstance {
                 .paths(serviceInfo.getPaths())
                 .commitRef(serviceInfo.getCommitRef())
                 .description(serviceInfo.getDescription())
-                .version(serviceInfo.getVersion());
+                .version(serviceInfo.getVersion())
+                .build();
     }
 
 }

--- a/src/main/java/org/kiwiproject/registry/model/ServiceInstance.java
+++ b/src/main/java/org/kiwiproject/registry/model/ServiceInstance.java
@@ -24,19 +24,19 @@ public class ServiceInstance {
     }
 
     @With
-    protected final String instanceId;
+    private final String instanceId;
 
     @With
-    protected final Status status;
+    private final Status status;
 
-    protected final String serviceName;
-    protected final String hostName;
-    protected final String ip;
-    protected final List<Port> ports;
-    protected final ServicePaths paths;
-    protected final String commitRef;
-    protected final String description;
-    protected final String version;
+    private final String serviceName;
+    private final String hostName;
+    private final String ip;
+    private final List<Port> ports;
+    private final ServicePaths paths;
+    private final String commitRef;
+    private final String description;
+    private final String version;
 
     /**
      * Returns a new {@code ServiceInstanceBuilder} built from a given {@link ServiceInfo}

--- a/src/test/java/org/kiwiproject/registry/model/ServiceInstanceTest.java
+++ b/src/test/java/org/kiwiproject/registry/model/ServiceInstanceTest.java
@@ -13,7 +13,7 @@ class ServiceInstanceTest {
     void shouldBeAbleToBeCreatedFromServiceInfo() {
         var serviceInfo = ServiceInfoHelper.buildTestServiceInfo();
 
-        var instance = ServiceInstance.fromServiceInfo(serviceInfo).build();
+        var instance = ServiceInstance.fromServiceInfo(serviceInfo);
 
         assertThat(instance.getInstanceId()).isBlank();
         assertThat(instance.getServiceName()).isEqualTo(serviceInfo.getName());
@@ -25,5 +25,18 @@ class ServiceInstanceTest {
         assertThat(instance.getCommitRef()).isEqualTo(serviceInfo.getCommitRef());
         assertThat(instance.getDescription()).isEqualTo(serviceInfo.getDescription());
         assertThat(instance.getVersion()).isEqualTo(serviceInfo.getVersion());
+    }
+
+    @Test
+    void shouldAllowSettingCertainFieldsWithWithers() {
+        var instance = ServiceInstance.builder()
+                .build()
+                .withInstanceId("instance")
+                .withStatus(ServiceInstance.Status.DOWN);
+
+        assertThat(instance.getInstanceId()).isEqualTo("instance");
+        assertThat(instance.getStatus()).isEqualTo(ServiceInstance.Status.DOWN);
+
+
     }
 }

--- a/src/test/java/org/kiwiproject/registry/model/ServiceInstanceTest.java
+++ b/src/test/java/org/kiwiproject/registry/model/ServiceInstanceTest.java
@@ -36,7 +36,5 @@ class ServiceInstanceTest {
 
         assertThat(instance.getInstanceId()).isEqualTo("instance");
         assertThat(instance.getStatus()).isEqualTo(ServiceInstance.Status.DOWN);
-
-
     }
 }


### PR DESCRIPTION
There was an issue with Javadoc and Lombok generated builders because
javadoc does not process annotations first and thus `fromServiceInfo`'s
return value of `ServiceInstanceBuilder` caused javadoc generation
failures.

This changes the method to return an actual ServiceInstance and in
order to still allow for setting the instanceId and status, this commit
adds `@With` annotations for those fields.