### PR TITLE
Add Port#of factory method

### DIFF
--- a/src/main/java/org/kiwiproject/registry/consul/client/ConsulRegistryClient.java
+++ b/src/main/java/org/kiwiproject/registry/consul/client/ConsulRegistryClient.java
@@ -16,6 +16,8 @@ import org.kiwiproject.registry.client.RegistryClient;
 import org.kiwiproject.registry.client.ServiceInstanceFilter;
 import org.kiwiproject.registry.consul.config.ConsulConfig;
 import org.kiwiproject.registry.model.Port;
+import org.kiwiproject.registry.model.Port.PortType;
+import org.kiwiproject.registry.model.Port.Security;
 import org.kiwiproject.registry.model.ServiceInstance;
 import org.kiwiproject.registry.model.ServicePaths;
 
@@ -69,19 +71,12 @@ public class ConsulRegistryClient implements RegistryClient {
         var scheme = metadata.get("scheme");
 
         var ports = new ArrayList<Port>();
-        var port = Port.builder()
-                .number(catalogService.getServicePort())
-                .secure(Port.Security.fromScheme(scheme))
-                .type(Port.PortType.APPLICATION)
-                .build();
+        var port = Port.of(catalogService.getServicePort(), PortType.APPLICATION, Security.fromScheme(scheme));
         ports.add(port);
 
         if (isNotBlank(metadata.get(ADMIN_PORT_FIELD))) {
-            var adminPort = Port.builder()
-                    .number(Integer.parseInt(metadata.get(ADMIN_PORT_FIELD)))
-                    .secure(Port.Security.fromScheme(scheme))
-                    .type(Port.PortType.ADMIN)
-                    .build();
+            var adminPortNumber = Integer.parseInt(metadata.get(ADMIN_PORT_FIELD));
+            var adminPort = Port.of(adminPortNumber, PortType.ADMIN, Security.fromScheme(scheme));
             ports.add(adminPort);
         }
 

--- a/src/main/java/org/kiwiproject/registry/management/dropwizard/RegistrationLifecycleListener.java
+++ b/src/main/java/org/kiwiproject/registry/management/dropwizard/RegistrationLifecycleListener.java
@@ -11,6 +11,7 @@ import org.eclipse.jetty.util.component.LifeCycle;
 import org.kiwiproject.registry.config.ServiceInfo;
 import org.kiwiproject.registry.management.RegistrationManager;
 import org.kiwiproject.registry.model.Port;
+import org.kiwiproject.registry.model.Port.Security;
 import org.kiwiproject.registry.server.RegistryService;
 
 import java.util.List;
@@ -89,11 +90,7 @@ public class RegistrationLifecycleListener extends AbstractLifeCycle.AbstractLif
                 .map(PortDescriptor::getProtocol)
                 .findFirst();
 
-        return portProtocol.map(protocol -> Port.builder()
-                .type(portType)
-                .secure(Port.Security.fromScheme(protocol))
-                .number(port)
-                .build());
+        return portProtocol.map(protocol -> Port.of(port, portType, Security.fromScheme(protocol)));
     }
 
     // This method comes from AbstractLifeCycle.AbstractLifeCycleListener

--- a/src/main/java/org/kiwiproject/registry/model/Port.java
+++ b/src/main/java/org/kiwiproject/registry/model/Port.java
@@ -1,13 +1,19 @@
 package org.kiwiproject.registry.model;
 
+import static java.util.Objects.isNull;
+import static org.kiwiproject.base.KiwiPreconditions.checkValidPort;
+
 import lombok.Builder;
 import lombok.Getter;
 
+import javax.annotation.Nullable;
+
 /**
- * Model that defines a port being used by a service, including the port number, the purpose of the port, and whether the port is secure or not.
+ * Model that defines a port being used by a service, including the port number, the purpose of the port, and whether
+ * the port is secure or not.
  * <p>
- * For the type/purpose of the port, we are assuming that a service has a separate ports for the main application and the administrative endpoints
- * (e.g. status and health checks)
+ * For the type/purpose of the port, we are assuming that a service has a separate ports for the main application and
+ * the administrative endpoints (e.g. status and health checks)
  */
 @Builder
 @Getter
@@ -21,10 +27,19 @@ public class Port {
     }
 
     /**
-     * Enum defining whether the port is secure or not
+     * Enum defining whether the port is secure or not.
      */
     public enum Security {
-        SECURE("https"), NOT_SECURE("http");
+
+        /**
+         * Secure; HTTPS.
+         */
+        SECURE("https"),
+
+        /**
+         * Not secure; HTTP.
+         */
+        NOT_SECURE("http");
 
         @Getter
         private final String scheme;
@@ -33,6 +48,13 @@ public class Port {
             this.scheme = scheme;
         }
 
+        /**
+         * Return {@link Security} value for the given scheme, using a case-insensitive comparison. If given some
+         * value other than HTTP or HTTPS, returns NOT_SECURE.
+         *
+         * @param schemeToCheck either HTTP or HTTPS, case-insensitive
+         * @return the {@link Security} value
+         */
         public static Security fromScheme(String schemeToCheck) {
             return SECURE.scheme.equalsIgnoreCase(schemeToCheck) ? SECURE : NOT_SECURE;
         }
@@ -41,5 +63,28 @@ public class Port {
     private final int number;
     private final PortType type;
     private final Security secure;
+
+    /**
+     * Convenience factory method to create a new {@link Port}.
+     * <p>
+     * Default values are assigned to the port type and security if null arguments are supplied.
+     *
+     * @param number   the port number, must be in range 0 to 65535
+     * @param portType the type of port (defaults to APPLICATION if null)
+     * @param security is the port secure? (defaults to SECURE if null)
+     * @return a new instance
+     */
+    public static Port of(int number, @Nullable PortType portType, @Nullable Security security) {
+        checkValidPort(number);
+
+        var nonNullPortType = isNull(portType) ? PortType.APPLICATION : portType;
+        var nonNullSecurity = isNull(security) ? Security.SECURE : security;
+
+        return Port.builder()
+                .number(number)
+                .type(nonNullPortType)
+                .secure(nonNullSecurity)
+                .build();
+    }
 
 }

--- a/src/main/java/org/kiwiproject/registry/util/Ports.java
+++ b/src/main/java/org/kiwiproject/registry/util/Ports.java
@@ -1,9 +1,9 @@
 package org.kiwiproject.registry.util;
 
-import static org.kiwiproject.registry.model.Port.Security.NOT_SECURE;
-
 import lombok.experimental.UtilityClass;
 import org.kiwiproject.registry.model.Port;
+import org.kiwiproject.registry.model.Port.PortType;
+import org.kiwiproject.registry.model.Port.Security;
 
 import java.util.List;
 
@@ -20,31 +20,33 @@ public class Ports {
      *
      * @param ports The list of ports to traverse
      * @param type  The type of port that is being requested
-     * @return  The port definition that was found based on the given criteria
+     * @return The port definition that was found based on the given criteria
      */
-    public static Port findFirstPortPreferSecure(List<Port> ports, Port.PortType type) {
-        var securePort = findPort(ports, Port.Security.SECURE, type);
+    public static Port findFirstPortPreferSecure(List<Port> ports, PortType type) {
+        var securePort = findPort(ports, Security.SECURE, type);
         if (securePort.getNumber() > 0) {
             return securePort;
         }
 
-        return findPort(ports, NOT_SECURE, type);
+        return findPort(ports, Security.NOT_SECURE, type);
     }
 
     /**
-     * Finds a desired port given a security and type criteria
+     * Finds a desired port given a security and type criteria.
+     * <p>
+     * If not found, returns a new Port with number 0 and the given values for {@link Security} and {@link PortType}.
      *
-     * @param ports     The list of ports to traverse
-     * @param security  The security of the port that is desired (Secure or Non-Secure)
-     * @param type      The type of port that is desired (Application or Admin)
+     * @param ports    The list of ports to traverse
+     * @param security The security of the port that is desired (Secure or Non-Secure)
+     * @param type     The type of port that is desired (Application or Admin)
      * @return The port definition that was found based on the given criteria
      */
-    public static Port findPort(List<Port> ports, Port.Security security, Port.PortType type) {
+    public static Port findPort(List<Port> ports, Security security, PortType type) {
         return ports.stream()
                 .filter(p -> p.getSecure() == security)
                 .filter(p -> p.getType() == type)
                 .findFirst()
-                .orElseGet(() -> Port.builder().number(0).secure(security).type(type).build());
+                .orElseGet(() -> Port.of(0, type, security));
     }
 
     /**
@@ -52,10 +54,10 @@ public class Ports {
      *
      * @param ports The list of ports to traverse to determine the scheme
      * @param type  The type of port that is desired (Application or Admin)
-     * @return  The scheme (https or http) based on the port definitions
-     * @see #findFirstPortPreferSecure(List, Port.PortType)
+     * @return The scheme (https or http) based on the port definitions
+     * @see #findFirstPortPreferSecure(List, PortType)
      */
-    public static String determineScheme(List<Port> ports, Port.PortType type) {
+    public static String determineScheme(List<Port> ports, PortType type) {
         var firstPort = findFirstPortPreferSecure(ports, type);
         return firstPort.getSecure().getScheme();
     }

--- a/src/test/java/org/kiwiproject/registry/eureka/common/EurekaInstanceTest.java
+++ b/src/test/java/org/kiwiproject/registry/eureka/common/EurekaInstanceTest.java
@@ -11,6 +11,8 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.kiwiproject.registry.model.Port;
+import org.kiwiproject.registry.model.Port.PortType;
+import org.kiwiproject.registry.model.Port.Security;
 import org.kiwiproject.registry.model.ServiceInstance;
 import org.kiwiproject.registry.model.ServicePaths;
 import org.kiwiproject.registry.util.ServiceInfoHelper;
@@ -60,10 +62,10 @@ class EurekaInstanceTest {
         void shouldPreferSecurePortOverNotSecure() {
             var serviceInfo = ServiceInfoHelper.buildTestServiceInfo();
             serviceInfo.getPorts().clear();
-            serviceInfo.getPorts().add(Port.builder().number(8080).type(Port.PortType.APPLICATION).secure(Port.Security.NOT_SECURE).build());
-            serviceInfo.getPorts().add(Port.builder().number(8081).type(Port.PortType.APPLICATION).secure(Port.Security.SECURE).build());
-            serviceInfo.getPorts().add(Port.builder().number(8082).type(Port.PortType.ADMIN).secure(Port.Security.NOT_SECURE).build());
-            serviceInfo.getPorts().add(Port.builder().number(8083).type(Port.PortType.ADMIN).secure(Port.Security.SECURE).build());
+            serviceInfo.getPorts().add(Port.of(8080, PortType.APPLICATION, Security.NOT_SECURE));
+            serviceInfo.getPorts().add(Port.of(8081, PortType.APPLICATION, Security.SECURE));
+            serviceInfo.getPorts().add(Port.of(8082, PortType.ADMIN, Security.NOT_SECURE));
+            serviceInfo.getPorts().add(Port.of(8083, PortType.ADMIN, Security.SECURE));
 
             var service = ServiceInstance.fromServiceInfo(serviceInfo).withStatus(ServiceInstance.Status.STARTING);
             var instance = EurekaInstance.fromServiceInstance(service);
@@ -149,12 +151,13 @@ class EurekaInstanceTest {
             assertThat(serviceInstance.getPorts())
                     .extracting("number", "secure", "type")
                     .containsExactlyInAnyOrder(
-                            tuple(8080, Port.Security.NOT_SECURE, Port.PortType.APPLICATION),
-                            tuple(8081, Port.Security.NOT_SECURE, Port.PortType.ADMIN)
+                            tuple(8080, Security.NOT_SECURE, PortType.APPLICATION),
+                            tuple(8081, Security.NOT_SECURE, PortType.ADMIN)
                     );
 
             assertThat(serviceInstance.getPaths())
-                    .isEqualToComparingFieldByField(ServicePaths.builder()
+                    .usingRecursiveComparison()
+                    .isEqualTo(ServicePaths.builder()
                             .homePagePath("/api")
                             .statusPath("/status")
                             .healthCheckPath("/health")
@@ -187,7 +190,8 @@ class EurekaInstanceTest {
             var serviceInstance = eurekaInstance.toServiceInstance();
 
             assertThat(serviceInstance.getPaths())
-                    .isEqualToComparingFieldByField(ServicePaths.builder()
+                    .usingRecursiveComparison()
+                    .isEqualTo(ServicePaths.builder()
                             .homePagePath(ServicePaths.DEFAULT_HOMEPAGE_PATH)
                             .statusPath(ServicePaths.DEFAULT_STATUS_PATH)
                             .healthCheckPath(ServicePaths.DEFAULT_HEALTHCHECK_PATH)
@@ -217,7 +221,7 @@ class EurekaInstanceTest {
             assertThat(serviceInstance.getPorts())
                     .extracting("number", "secure", "type")
                     .containsExactlyInAnyOrder(
-                            tuple(8080, Port.Security.NOT_SECURE, Port.PortType.APPLICATION)
+                            tuple(8080, Security.NOT_SECURE, PortType.APPLICATION)
                     );
         }
 

--- a/src/test/java/org/kiwiproject/registry/management/dropwizard/RegistrationLifecycleListenerTest.java
+++ b/src/test/java/org/kiwiproject/registry/management/dropwizard/RegistrationLifecycleListenerTest.java
@@ -15,6 +15,8 @@ import org.junit.jupiter.api.Test;
 import org.kiwiproject.registry.config.ServiceInfo;
 import org.kiwiproject.registry.management.RegistrationManager;
 import org.kiwiproject.registry.model.Port;
+import org.kiwiproject.registry.model.Port.PortType;
+import org.kiwiproject.registry.model.Port.Security;
 import org.kiwiproject.registry.model.ServiceInstance;
 import org.kiwiproject.registry.server.RegistryService;
 
@@ -30,7 +32,7 @@ class RegistrationLifecycleListenerTest {
         @Test
         void shouldCallStartOnAProvidedRegistrationManager() {
             var serviceInfo = mock(ServiceInfo.class);
-            when(serviceInfo.getPorts()).thenReturn(List.of(Port.builder().build()));
+            when(serviceInfo.getPorts()).thenReturn(List.of(Port.of(8080, PortType.APPLICATION, Security.SECURE)));
 
             var manager = mock(RegistrationManager.class);
             when(manager.getServiceInfo()).thenReturn(serviceInfo);
@@ -45,7 +47,7 @@ class RegistrationLifecycleListenerTest {
         @Test
         void shouldCallStartOnARegistrationManagerCreatedFromServiceInfoAndRegistryService() {
             var info = mock(ServiceInfo.class);
-            when(info.getPorts()).thenReturn(List.of(Port.builder().build()));
+            when(info.getPorts()).thenReturn(List.of(Port.of(9100, PortType.ADMIN, Security.NOT_SECURE)));
 
             var registryService = mock(RegistryService.class);
 
@@ -76,18 +78,14 @@ class RegistrationLifecycleListenerTest {
             when(connector.getProtocols()).thenReturn(List.of("HTTPS"));
 
             var server = mock(Server.class);
-            when(server.getConnectors()).thenReturn(new Connector[]{ connector });
-            when(server.getConnectors()).thenReturn(new Connector[]{ connector });
+            when(server.getConnectors()).thenReturn(new Connector[]{connector});
+            when(server.getConnectors()).thenReturn(new Connector[]{connector});
 
             listener.serverStarted(server);
 
             assertThat(info.getPorts())
                     .usingRecursiveFieldByFieldElementComparator()
-                    .contains(Port.builder()
-                            .number(8080)
-                            .secure(Port.Security.SECURE)
-                            .type(Port.PortType.APPLICATION)
-                            .build());
+                    .contains(Port.of(8080, PortType.APPLICATION, Security.SECURE));
         }
 
         @Test
@@ -106,18 +104,14 @@ class RegistrationLifecycleListenerTest {
             when(connector.getProtocols()).thenReturn(List.of("HTTP"));
 
             var server = mock(Server.class);
-            when(server.getConnectors()).thenReturn(new Connector[]{ connector });
-            when(server.getConnectors()).thenReturn(new Connector[]{ connector });
+            when(server.getConnectors()).thenReturn(new Connector[]{connector});
+            when(server.getConnectors()).thenReturn(new Connector[]{connector});
 
             listener.serverStarted(server);
 
             assertThat(info.getPorts())
                     .usingRecursiveFieldByFieldElementComparator()
-                    .contains(Port.builder()
-                            .number(8080)
-                            .secure(Port.Security.NOT_SECURE)
-                            .type(Port.PortType.APPLICATION)
-                            .build());
+                    .contains(Port.of(8080, PortType.APPLICATION, Security.NOT_SECURE));
         }
 
         private ServiceInfo createServiceInfoWithEmptyPorts() {

--- a/src/test/java/org/kiwiproject/registry/model/PortTest.java
+++ b/src/test/java/org/kiwiproject/registry/model/PortTest.java
@@ -1,0 +1,64 @@
+package org.kiwiproject.registry.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
+
+import org.assertj.core.api.SoftAssertions;
+import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.kiwiproject.registry.model.Port.PortType;
+import org.kiwiproject.registry.model.Port.Security;
+
+@DisplayName("Port")
+@ExtendWith(SoftAssertionsExtension.class)
+class PortTest {
+
+    @Nested
+    class FactoryMethod {
+
+        @ParameterizedTest
+        @CsvSource({
+                "0, APPLICATION, SECURE",
+                "0, ADMIN, SECURE",
+                "8080, APPLICATION, NOT_SECURE",
+                "8081, ADMIN, NOT_SECURE",
+                "42000, APPLICATION, SECURE",
+                "42001, ADMIN, SECURE",
+                "65353, APPLICATION, SECURE",
+                "65353, ADMIN, SECURE",
+        })
+        void shouldCreatePort(int number, PortType portType, Security security, SoftAssertions softly) {
+            var port = Port.of(number, portType, security);
+
+            softly.assertThat(port.getNumber()).isEqualTo(number);
+            softly.assertThat(port.getType()).isEqualTo(portType);
+            softly.assertThat(port.getSecure()).isEqualTo(security);
+        }
+
+        @ParameterizedTest
+        @ValueSource(ints = {-1024, -1, 65_536})
+        void shouldRejectInvalidPortNumbers(int number) {
+            assertThatIllegalStateException()
+                    .isThrownBy(() -> Port.of(number, PortType.APPLICATION, Security.SECURE));
+        }
+
+        @Test
+        void shouldSetDefaultValueForPortType() {
+            var port = Port.of(8080, null, Security.SECURE);
+            assertThat(port.getType()).isEqualTo(PortType.APPLICATION);
+        }
+
+        @Test
+        void shouldSetDefaultValueForSecurity() {
+            var port = Port.of(9001, PortType.APPLICATION, null);
+            assertThat(port.getSecure()).isEqualTo(Security.SECURE);
+        }
+    }
+
+}

--- a/src/test/java/org/kiwiproject/registry/util/PortsTest.java
+++ b/src/test/java/org/kiwiproject/registry/util/PortsTest.java
@@ -6,6 +6,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.kiwiproject.registry.model.Port;
+import org.kiwiproject.registry.model.Port.PortType;
+import org.kiwiproject.registry.model.Port.Security;
 
 import java.util.List;
 
@@ -17,52 +19,52 @@ class PortsTest {
 
         @Test
         void shouldReturnSecurePortWhenSecurePortIsFound() {
-            var ports = List.of(Port.builder().number(8080).type(Port.PortType.APPLICATION).secure(Port.Security.SECURE).build());
+            var ports = List.of(Port.of(8080, PortType.APPLICATION, Security.SECURE));
 
-            var port = Ports.findFirstPortPreferSecure(ports, Port.PortType.APPLICATION);
+            var port = Ports.findFirstPortPreferSecure(ports, PortType.APPLICATION);
 
             assertThat(port.getNumber()).isEqualTo(8080);
-            assertThat(port.getSecure()).isEqualTo(Port.Security.SECURE);
-            assertThat(port.getType()).isEqualTo(Port.PortType.APPLICATION);
+            assertThat(port.getSecure()).isEqualTo(Security.SECURE);
+            assertThat(port.getType()).isEqualTo(PortType.APPLICATION);
         }
 
         @Test
         void shouldReturnNonSecureWhenNonSecurePortIsFound() {
-            var ports = List.of(Port.builder().number(8080).type(Port.PortType.APPLICATION).secure(Port.Security.NOT_SECURE).build());
+            var ports = List.of(Port.of(8080, PortType.APPLICATION, Security.NOT_SECURE));
 
-            var port = Ports.findFirstPortPreferSecure(ports, Port.PortType.APPLICATION);
+            var port = Ports.findFirstPortPreferSecure(ports, PortType.APPLICATION);
 
             assertThat(port.getNumber()).isEqualTo(8080);
-            assertThat(port.getSecure()).isEqualTo(Port.Security.NOT_SECURE);
-            assertThat(port.getType()).isEqualTo(Port.PortType.APPLICATION);
+            assertThat(port.getSecure()).isEqualTo(Security.NOT_SECURE);
+            assertThat(port.getType()).isEqualTo(PortType.APPLICATION);
         }
 
         @Test
         void shouldReturnSecureWhenBothSecureAndNonSecurePortIsFound() {
             var ports = List.of(
-                    Port.builder().number(8080).type(Port.PortType.APPLICATION).secure(Port.Security.SECURE).build(),
-                    Port.builder().number(8081).type(Port.PortType.APPLICATION).secure(Port.Security.NOT_SECURE).build()
+                    Port.of(8080, PortType.APPLICATION, Security.SECURE),
+                    Port.of(8081, PortType.APPLICATION, Security.NOT_SECURE)
             );
 
-            var port = Ports.findFirstPortPreferSecure(ports, Port.PortType.APPLICATION);
+            var port = Ports.findFirstPortPreferSecure(ports, PortType.APPLICATION);
 
             assertThat(port.getNumber()).isEqualTo(8080);
-            assertThat(port.getSecure()).isEqualTo(Port.Security.SECURE);
-            assertThat(port.getType()).isEqualTo(Port.PortType.APPLICATION);
+            assertThat(port.getSecure()).isEqualTo(Security.SECURE);
+            assertThat(port.getType()).isEqualTo(PortType.APPLICATION);
         }
 
         @Test
         void shouldReturnFirstSecureWhenMultiplePortsAreFound() {
             var ports = List.of(
-                    Port.builder().number(8080).type(Port.PortType.APPLICATION).secure(Port.Security.SECURE).build(),
-                    Port.builder().number(8081).type(Port.PortType.APPLICATION).secure(Port.Security.SECURE).build()
+                    Port.of(8080, PortType.APPLICATION, Security.SECURE),
+                    Port.of(8081, PortType.APPLICATION, Security.SECURE)
             );
 
-            var port = Ports.findFirstPortPreferSecure(ports, Port.PortType.APPLICATION);
+            var port = Ports.findFirstPortPreferSecure(ports, PortType.APPLICATION);
 
             assertThat(port.getNumber()).isEqualTo(8080);
-            assertThat(port.getSecure()).isEqualTo(Port.Security.SECURE);
-            assertThat(port.getType()).isEqualTo(Port.PortType.APPLICATION);
+            assertThat(port.getSecure()).isEqualTo(Security.SECURE);
+            assertThat(port.getType()).isEqualTo(PortType.APPLICATION);
         }
     }
 
@@ -71,11 +73,11 @@ class PortsTest {
 
         @Test
         void shouldReturnDefaultPortIfCriteriaDoesNotFindOne() {
-            var port = Ports.findPort(List.of(), Port.Security.SECURE, Port.PortType.APPLICATION);
+            var port = Ports.findPort(List.of(), Security.SECURE, PortType.APPLICATION);
 
             assertThat(port.getNumber()).isZero();
-            assertThat(port.getSecure()).isEqualTo(Port.Security.SECURE);
-            assertThat(port.getType()).isEqualTo(Port.PortType.APPLICATION);
+            assertThat(port.getSecure()).isEqualTo(Security.SECURE);
+            assertThat(port.getType()).isEqualTo(PortType.APPLICATION);
         }
     }
 
@@ -84,18 +86,18 @@ class PortsTest {
 
         @Test
         void shouldReturnHttpsIfPortIsSecure() {
-            var ports = List.of(Port.builder().number(8080).type(Port.PortType.APPLICATION).secure(Port.Security.SECURE).build());
+            var ports = List.of(Port.of(8080, PortType.APPLICATION, Security.SECURE));
 
-            var scheme = Ports.determineScheme(ports, Port.PortType.APPLICATION);
+            var scheme = Ports.determineScheme(ports, PortType.APPLICATION);
 
             assertThat(scheme).isEqualTo("https");
         }
 
         @Test
         void shouldReturnHttpIfPortIsNotSecure() {
-            var ports = List.of(Port.builder().number(8080).type(Port.PortType.APPLICATION).secure(Port.Security.NOT_SECURE).build());
+            var ports = List.of(Port.of(8080, PortType.APPLICATION, Security.NOT_SECURE));
 
-            var scheme = Ports.determineScheme(ports, Port.PortType.APPLICATION);
+            var scheme = Ports.determineScheme(ports, PortType.APPLICATION);
 
             assertThat(scheme).isEqualTo("http");
         }

--- a/src/test/java/org/kiwiproject/registry/util/ServiceInfoHelper.java
+++ b/src/test/java/org/kiwiproject/registry/util/ServiceInfoHelper.java
@@ -5,6 +5,8 @@ import static com.google.common.collect.Lists.newArrayList;
 import lombok.experimental.UtilityClass;
 import org.kiwiproject.registry.config.ServiceInfo;
 import org.kiwiproject.registry.model.Port;
+import org.kiwiproject.registry.model.Port.PortType;
+import org.kiwiproject.registry.model.Port.Security;
 import org.kiwiproject.registry.model.ServicePaths;
 
 import java.util.List;
@@ -28,11 +30,7 @@ public class ServiceInfoHelper {
         return new ServiceInfo() {
 
             private final List<Port> ports = newArrayList(
-                    Port.builder()
-                            .number(80)
-                            .secure(Port.Security.NOT_SECURE)
-                            .type(Port.PortType.APPLICATION)
-                            .build()
+                    Port.of(80, PortType.APPLICATION, Security.NOT_SECURE)
             );
 
             private final ServicePaths paths = ServicePaths.builder().build();

--- a/src/test/java/org/kiwiproject/registry/util/ServiceInstancePathsTest.java
+++ b/src/test/java/org/kiwiproject/registry/util/ServiceInstancePathsTest.java
@@ -6,6 +6,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.kiwiproject.registry.model.Port;
+import org.kiwiproject.registry.model.Port.PortType;
+import org.kiwiproject.registry.model.Port.Security;
 
 import java.util.List;
 
@@ -17,18 +19,18 @@ class ServiceInstancePathsTest {
 
         @Test
         void shouldBuildPathWithHttpsWhenSecurePortIsFound() {
-            var ports = List.of(Port.builder().number(8080).type(Port.PortType.APPLICATION).secure(Port.Security.SECURE).build());
+            var ports = List.of(Port.of(8080, PortType.APPLICATION, Security.SECURE));
 
-            var path = ServiceInstancePaths.urlForPath("localhost", ports, Port.PortType.APPLICATION, "/foo");
+            var path = ServiceInstancePaths.urlForPath("localhost", ports, PortType.APPLICATION, "/foo");
 
             assertThat(path).isEqualTo("https://localhost:8080/foo");
         }
 
         @Test
         void shouldBuildPathWithHttpWhenNonSecurePortIsFound() {
-            var ports = List.of(Port.builder().number(8080).type(Port.PortType.APPLICATION).secure(Port.Security.NOT_SECURE).build());
+            var ports = List.of(Port.of(8080, PortType.APPLICATION, Security.NOT_SECURE));
 
-            var path = ServiceInstancePaths.urlForPath("localhost", ports, Port.PortType.APPLICATION, "/foo");
+            var path = ServiceInstancePaths.urlForPath("localhost", ports, PortType.APPLICATION, "/foo");
 
             assertThat(path).isEqualTo("http://localhost:8080/foo");
         }
@@ -36,11 +38,11 @@ class ServiceInstancePathsTest {
         @Test
         void shouldBuildPathWithHttpsWhenBothSecureAndNonSecurePortIsFound() {
             var ports = List.of(
-                    Port.builder().number(8080).type(Port.PortType.APPLICATION).secure(Port.Security.SECURE).build(),
-                    Port.builder().number(8081).type(Port.PortType.APPLICATION).secure(Port.Security.NOT_SECURE).build()
+                    Port.of(8080, PortType.APPLICATION, Security.SECURE),
+                    Port.of(8081, PortType.APPLICATION, Security.NOT_SECURE)
             );
 
-            var path = ServiceInstancePaths.urlForPath("localhost", ports, Port.PortType.APPLICATION, "/foo");
+            var path = ServiceInstancePaths.urlForPath("localhost", ports, PortType.APPLICATION, "/foo");
 
             assertThat(path).isEqualTo("https://localhost:8080/foo");
         }


### PR DESCRIPTION
* Add Port.of(number, type, security) factory method
* Change Port.builder() usages with Port.of
* Add imports for Port.PortType and Port.Security to make code cleaner
* Fix deprecation warnings in EurekaInstanceTest on the
  isEqualToComparingFieldByField method; use usingRecursiveComparison
  instead

Fixes #47