### PR TITLE
Fix path handling in ServiceInstancePaths#urlForPath

### DIFF
--- a/src/main/java/org/kiwiproject/registry/consul/server/ConsulRegistryService.java
+++ b/src/main/java/org/kiwiproject/registry/consul/server/ConsulRegistryService.java
@@ -28,6 +28,7 @@ import org.kiwiproject.registry.config.ServiceInfo;
 import org.kiwiproject.registry.consul.config.ConsulRegistrationConfig;
 import org.kiwiproject.registry.exception.RegistrationException;
 import org.kiwiproject.registry.model.Port;
+import org.kiwiproject.registry.model.Port.PortType;
 import org.kiwiproject.registry.model.ServiceInstance;
 import org.kiwiproject.registry.server.RegistryService;
 import org.kiwiproject.registry.util.ServiceInstancePaths;
@@ -186,7 +187,7 @@ public class ConsulRegistryService implements RegistryService {
     private Registration fromServiceInstance(ServiceInstance serviceInstance) {
 
         var check = ImmutableRegCheck.builder()
-                .http(urlForPath(serviceInstance.getHostName(), serviceInstance.getPorts(), Port.PortType.ADMIN,
+                .http(urlForPath(serviceInstance.getHostName(), serviceInstance.getPorts(), PortType.ADMIN,
                         serviceInstance.getPaths().getStatusPath()))
                 .interval(format("{}s", config.getCheckIntervalInSeconds()))
                 .deregisterCriticalServiceAfter(
@@ -194,10 +195,10 @@ public class ConsulRegistryService implements RegistryService {
                 .build();
 
         var address = adjustAddressIfNeeded(serviceInstance);
-        var adminPort = findFirstPortPreferSecure(serviceInstance.getPorts(), Port.PortType.ADMIN);
+        var adminPort = findFirstPortPreferSecure(serviceInstance.getPorts(), PortType.ADMIN);
 
         return ImmutableRegistration.builder()
-                .port(findFirstPortPreferSecure(serviceInstance.getPorts(), Port.PortType.APPLICATION).getNumber())
+                .port(findFirstPortPreferSecure(serviceInstance.getPorts(), PortType.APPLICATION).getNumber())
                 .check(check)
                 .id(UUIDs.randomUUIDString())
                 .name(serviceInstance.getServiceName())
@@ -231,7 +232,7 @@ public class ConsulRegistryService implements RegistryService {
                 "homePagePath", serviceInstance.getPaths().getHomePagePath(),
                 "healthCheckPath", serviceInstance.getPaths().getHealthCheckPath(),
                 "statusPath", serviceInstance.getPaths().getStatusPath(),
-                "scheme", determineScheme(serviceInstance.getPorts(), Port.PortType.APPLICATION),
+                "scheme", determineScheme(serviceInstance.getPorts(), PortType.APPLICATION),
                 "adminPort", Integer.toString(adminPort.getNumber()),
                 "ipAddress", serviceInstance.getIp()
         );
@@ -253,7 +254,7 @@ public class ConsulRegistryService implements RegistryService {
             return instance.getHostName();
         }
 
-        var urlString = ServiceInstancePaths.urlForPath(instance.getHostName(), instance.getPorts(), Port.PortType.APPLICATION, instance.getPaths().getHomePagePath());
+        var urlString = ServiceInstancePaths.urlForPath(instance.getHostName(), instance.getPorts(), PortType.APPLICATION, instance.getPaths().getHomePagePath());
         try {
             var url = new URL(replaceDomainsIn(urlString, config.getDomainOverride()));
             return url.getHost();

--- a/src/main/java/org/kiwiproject/registry/management/dropwizard/RegistrationLifecycleListener.java
+++ b/src/main/java/org/kiwiproject/registry/management/dropwizard/RegistrationLifecycleListener.java
@@ -11,6 +11,7 @@ import org.eclipse.jetty.util.component.LifeCycle;
 import org.kiwiproject.registry.config.ServiceInfo;
 import org.kiwiproject.registry.management.RegistrationManager;
 import org.kiwiproject.registry.model.Port;
+import org.kiwiproject.registry.model.Port.PortType;
 import org.kiwiproject.registry.model.Port.Security;
 import org.kiwiproject.registry.server.RegistryService;
 
@@ -78,12 +79,12 @@ public class RegistrationLifecycleListener extends AbstractLifeCycle.AbstractLif
 
             var descriptors = getPortDescriptorList(server);
 
-            findPort(port, Port.PortType.APPLICATION, descriptors).ifPresent(ports::add);
-            findPort(adminPort, Port.PortType.ADMIN, descriptors).ifPresent(ports::add);
+            findPort(port, PortType.APPLICATION, descriptors).ifPresent(ports::add);
+            findPort(adminPort, PortType.ADMIN, descriptors).ifPresent(ports::add);
         }
     }
 
-    private Optional<Port> findPort(int port, Port.PortType portType, List<PortDescriptor> descriptors) {
+    private Optional<Port> findPort(int port, PortType portType, List<PortDescriptor> descriptors) {
         var portProtocol = descriptors.stream()
                 .filter(descriptor -> descriptor.getPort() == port)
                 .map(PortDescriptor::getProtocol)

--- a/src/main/java/org/kiwiproject/registry/util/ServiceInstancePaths.java
+++ b/src/main/java/org/kiwiproject/registry/util/ServiceInstancePaths.java
@@ -1,11 +1,15 @@
 package org.kiwiproject.registry.util;
 
+import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.kiwiproject.base.KiwiStrings.f;
+import static org.kiwiproject.net.KiwiUrls.prependLeadingSlash;
 import static org.kiwiproject.registry.util.Ports.findFirstPortPreferSecure;
 
 import lombok.experimental.UtilityClass;
 import org.kiwiproject.registry.model.Port;
+import org.kiwiproject.registry.model.Port.PortType;
 
+import javax.annotation.Nullable;
 import java.util.List;
 
 /**
@@ -14,22 +18,25 @@ import java.util.List;
 @UtilityClass
 public class ServiceInstancePaths {
 
+    // scheme://hostName:port/path
     private static final String URL_HOST_FORMAT = "{}://{}:{}{}";
 
     /**
-     * Generates a URL given service information
+     * Generates a URL given service information.
      *
-     * @param hostName  The hostname for the url
-     * @param ports     The list of possible ports to use
-     * @param type      The type of port (Application versus Admin) for the url
-     * @param path      The path to append to the url
-     * @return  The combined URL
+     * @param hostName The hostname for the url
+     * @param ports    The list of possible ports to use
+     * @param type     The type of port (Application versus Admin) for the url
+     * @param path     The path to append to the url, with or without a leading "/". May be {@code null}
+     * @return The combined URL
      */
-    public static String urlForPath(String hostName, List<Port> ports, Port.PortType type, String path) {
+    public static String urlForPath(String hostName, List<Port> ports, PortType type, @Nullable String path) {
         var port = findFirstPortPreferSecure(ports, type);
 
         var protocol = port.getSecure().getScheme();
-        return f(URL_HOST_FORMAT, protocol, hostName, port.getNumber(), path);
+
+        var safePath = isBlank(path) ? "" : prependLeadingSlash(path);
+        return f(URL_HOST_FORMAT, protocol, hostName, port.getNumber(), safePath);
     }
 
 }

--- a/src/test/java/org/kiwiproject/registry/util/ServiceInstancePathsTest.java
+++ b/src/test/java/org/kiwiproject/registry/util/ServiceInstancePathsTest.java
@@ -2,49 +2,89 @@ package org.kiwiproject.registry.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.kiwiproject.registry.model.Port;
 import org.kiwiproject.registry.model.Port.PortType;
 import org.kiwiproject.registry.model.Port.Security;
+import org.kiwiproject.test.junit.jupiter.params.provider.AsciiOnlyBlankStringArgumentsProvider;
 
 import java.util.List;
 
-@DisplayName("Paths")
+@DisplayName("ServiceInstancePaths")
 class ServiceInstancePathsTest {
 
     @Nested
     class UrlForPath {
 
         @Test
-        void shouldBuildPathWithHttpsWhenSecurePortIsFound() {
+        void shouldBuildUrlWithHttpsWhenSecurePortIsFound() {
             var ports = List.of(Port.of(8080, PortType.APPLICATION, Security.SECURE));
 
-            var path = ServiceInstancePaths.urlForPath("localhost", ports, PortType.APPLICATION, "/foo");
+            var url = ServiceInstancePaths.urlForPath("localhost", ports, PortType.APPLICATION, "/foo");
 
-            assertThat(path).isEqualTo("https://localhost:8080/foo");
+            assertThat(url).isEqualTo("https://localhost:8080/foo");
         }
 
         @Test
-        void shouldBuildPathWithHttpWhenNonSecurePortIsFound() {
+        void shouldBuildUrlWithHttpWhenNonSecurePortIsFound() {
             var ports = List.of(Port.of(8080, PortType.APPLICATION, Security.NOT_SECURE));
 
-            var path = ServiceInstancePaths.urlForPath("localhost", ports, PortType.APPLICATION, "/foo");
+            var url = ServiceInstancePaths.urlForPath("localhost", ports, PortType.APPLICATION, "/foo");
 
-            assertThat(path).isEqualTo("http://localhost:8080/foo");
+            assertThat(url).isEqualTo("http://localhost:8080/foo");
         }
 
         @Test
-        void shouldBuildPathWithHttpsWhenBothSecureAndNonSecurePortIsFound() {
+        void shouldBuildUrlWithHttpsWhenBothSecureAndNonSecurePortIsFound() {
             var ports = List.of(
                     Port.of(8080, PortType.APPLICATION, Security.SECURE),
                     Port.of(8081, PortType.APPLICATION, Security.NOT_SECURE)
             );
 
-            var path = ServiceInstancePaths.urlForPath("localhost", ports, PortType.APPLICATION, "/foo");
+            var url = ServiceInstancePaths.urlForPath("localhost", ports, PortType.APPLICATION, "/foo");
 
-            assertThat(path).isEqualTo("https://localhost:8080/foo");
+            assertThat(url).isEqualTo("https://localhost:8080/foo");
+        }
+
+        @Nested
+        class GivenUnexpectedPaths {
+
+            private List<Port> ports;
+
+            @BeforeEach
+            void setUp() {
+                ports = List.of(Port.of(8080, PortType.APPLICATION, Security.SECURE));
+            }
+
+            @ParameterizedTest
+            @ArgumentsSource(AsciiOnlyBlankStringArgumentsProvider.class)
+            void shouldIgnoreBlankPaths(String path) {
+                var url = ServiceInstancePaths.urlForPath("localhost", ports, PortType.APPLICATION, path);
+
+                assertThat(url).isEqualTo("https://localhost:8080");
+            }
+
+            @ParameterizedTest
+            @ValueSource(strings = {"/", "\t/\n", "  /  "})
+            void shouldRetainSlashOnlyPaths(String path) {
+                var url = ServiceInstancePaths.urlForPath("localhost", ports, PortType.APPLICATION, path);
+
+                assertThat(url).isEqualTo("https://localhost:8080/");
+            }
+
+            @ParameterizedTest
+            @ValueSource(strings = {"foo", "bar", "baz/42", "  foo  ", "  foo/84  ", "\t\tbar/baz/42\n\n"})
+            void shouldPrependPathWithSlash(String path) {
+                var url = ServiceInstancePaths.urlForPath("localhost", ports, PortType.APPLICATION, path);
+
+                assertThat(url).isEqualTo("https://localhost:8080/" + path.trim());
+            }
         }
     }
 }


### PR DESCRIPTION
* Add leniency when handling paths in urlForPath. It now handles null,
  trims leading and trailing whitespace, and prepends a slash if
  necessary
* Import PortType so we don't have Port.PortType all over the place

Fixes #62