### PR TITLE
Set the admin port from Eureka response in EurekaParser

### DIFF
--- a/src/main/java/org/kiwiproject/registry/eureka/common/EurekaInstance.java
+++ b/src/main/java/org/kiwiproject/registry/eureka/common/EurekaInstance.java
@@ -4,7 +4,6 @@ import static java.util.Objects.isNull;
 import static java.util.stream.Collectors.toMap;
 import static java.util.stream.Collectors.toUnmodifiableList;
 import static org.kiwiproject.collect.KiwiMaps.isNullOrEmpty;
-import static org.kiwiproject.registry.model.Port.Security.SECURE;
 import static org.kiwiproject.registry.util.Ports.findFirstPortPreferSecure;
 import static org.kiwiproject.registry.util.Ports.findPort;
 import static org.kiwiproject.registry.util.ServiceInstancePaths.urlForPath;
@@ -125,8 +124,10 @@ public class EurekaInstance {
     }
 
     public ServiceInstance toServiceInstance() {
-        var ports = portListFromPortsIgnoringNulls(buildAdminPort(), buildApplicationPort(port, Security.NOT_SECURE),
-                buildApplicationPort(securePort, SECURE));
+        var ports = portListFromPortsIgnoringNulls(
+                buildAdminPortOrNull(),
+                buildApplicationPortOrNull(port, Security.NOT_SECURE),
+                buildApplicationPortOrNull(securePort, Security.SECURE));
 
         return ServiceInstance.builder()
                 .instanceId(getInstanceId())
@@ -155,7 +156,7 @@ public class EurekaInstance {
                 .collect(toUnmodifiableList());
     }
 
-    private Port buildAdminPort() {
+    private Port buildAdminPortOrNull() {
         if (adminPort == 0) {
             return null;
         }
@@ -165,7 +166,7 @@ public class EurekaInstance {
         return Port.of(adminPort, PortType.ADMIN, secure);
     }
 
-    private Port buildApplicationPort(Map<String, Object> portDef, Security secure) {
+    private Port buildApplicationPortOrNull(Map<String, Object> portDef, Security secure) {
         if (!isEnabled(portDef.get("@enabled"))) {
             return null;
         }

--- a/src/test/resources/EurekaParserTest/eureka-response-as-all-lists.json
+++ b/src/test/resources/EurekaParserTest/eureka-response-as-all-lists.json
@@ -11,7 +11,7 @@
             "ipAddr": "127.0.0.1",
             "status": "UP",
             "homePageUrl": "http://localhost",
-            "healthCheckUrl": "http://localhost/healthCheck",
+            "healthCheckUrl": "http://localhost/healthcheck",
             "statusUrl": "http://localhost/ping",
             "port": {
               "$": 8080,

--- a/src/test/resources/EurekaParserTest/eureka-response-as-all-maps.json
+++ b/src/test/resources/EurekaParserTest/eureka-response-as-all-maps.json
@@ -9,7 +9,7 @@
         "ipAddr": "127.0.0.1",
         "status": "UP",
         "homePageUrl": "http://localhost",
-        "healthCheckUrl": "http://localhost/healthCheck",
+        "healthCheckUrl": "http://localhost/healthcheck",
         "statusUrl": "http://localhost/ping",
         "port": {
           "$": 8080,

--- a/src/test/resources/EurekaParserTest/eureka-response-as-application-list-instance-map.json
+++ b/src/test/resources/EurekaParserTest/eureka-response-as-application-list-instance-map.json
@@ -10,7 +10,7 @@
           "ipAddr": "127.0.0.1",
           "status": "UP",
           "homePageUrl": "http://localhost",
-          "healthCheckUrl": "http://localhost/healthCheck",
+          "healthCheckUrl": "http://localhost/healthcheck",
           "statusUrl": "http://localhost/ping",
           "port": {
             "$": 8080,

--- a/src/test/resources/EurekaParserTest/eureka-response-as-application-map-instance-list.json
+++ b/src/test/resources/EurekaParserTest/eureka-response-as-application-map-instance-list.json
@@ -10,7 +10,7 @@
           "ipAddr": "127.0.0.1",
           "status": "UP",
           "homePageUrl": "http://localhost",
-          "healthCheckUrl": "http://localhost/healthCheck",
+          "healthCheckUrl": "http://localhost/healthcheck",
           "statusUrl": "http://localhost/ping",
           "port": {
             "$": 8080,


### PR DESCRIPTION
* EurekaParser#buildInstance should set the admin port from either the
  status or health check URL
* Minor refactoring in EurekaInstance; rename methods to end with the
  suffix "OrNull" for clarity
* Change the health check URLs in the sample test data to be
  /healthcheck (instead of /healthCheck) since that's our normal path

Fixes #66