### PR TITLE
Helper methods to get application and admin Port from ServiceInstance

### DIFF
--- a/src/main/java/org/kiwiproject/registry/model/Port.java
+++ b/src/main/java/org/kiwiproject/registry/model/Port.java
@@ -5,7 +5,7 @@ import static org.kiwiproject.base.KiwiPreconditions.checkValidPort;
 
 import lombok.Builder;
 import lombok.Getter;
-import lombok.ToString;
+import lombok.Value;
 
 import javax.annotation.Nullable;
 
@@ -17,8 +17,7 @@ import javax.annotation.Nullable;
  * the administrative endpoints (e.g. status and health checks)
  */
 @Builder
-@Getter
-@ToString
+@Value
 public class Port {
 
     /**
@@ -62,9 +61,9 @@ public class Port {
         }
     }
 
-    private final int number;
-    private final PortType type;
-    private final Security secure;
+    int number;
+    PortType type;
+    Security secure;
 
     /**
      * Convenience factory method to create a new {@link Port}.

--- a/src/main/java/org/kiwiproject/registry/model/ServiceInstance.java
+++ b/src/main/java/org/kiwiproject/registry/model/ServiceInstance.java
@@ -6,6 +6,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.With;
 import org.kiwiproject.registry.config.ServiceInfo;
+import org.kiwiproject.registry.model.Port.PortType;
+import org.kiwiproject.registry.util.Ports;
 
 import java.time.Instant;
 import java.util.List;
@@ -100,4 +102,23 @@ public class ServiceInstance {
         return getUpSince().toEpochMilli();
     }
 
+    /**
+     * Returns the application port of this instance, preferring the secure port (if both secure and insecure exist).
+     *
+     * @return the application port
+     * @see Ports#findFirstPortPreferSecure(List, PortType)
+     */
+    public Port getApplicationPort() {
+        return Ports.findFirstPortPreferSecure(ports, PortType.APPLICATION);
+    }
+
+    /**
+     * Returns the admin port of this instance, preferring the secure port (if both secure and insecure exist).
+     *
+     * @return the admin port
+     * @see Ports#findFirstPortPreferSecure(List, PortType)
+     */
+    public Port getAdminPort() {
+        return Ports.findFirstPortPreferSecure(ports, PortType.ADMIN);
+    }
 }

--- a/src/test/java/org/kiwiproject/registry/model/ServiceInstanceTest.java
+++ b/src/test/java/org/kiwiproject/registry/model/ServiceInstanceTest.java
@@ -3,12 +3,17 @@ package org.kiwiproject.registry.model;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
+import org.kiwiproject.registry.model.Port.PortType;
+import org.kiwiproject.registry.model.Port.Security;
 import org.kiwiproject.registry.util.ServiceInfoHelper;
 
 import java.time.Instant;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ThreadLocalRandom;
 
@@ -83,4 +88,35 @@ class ServiceInstanceTest {
         assertThat(instance.getUpSince()).isEqualTo(Instant.EPOCH);
         assertThat(instance.getUpSinceMillis()).isZero();
     }
+
+    @Nested
+    class Ports {
+
+        private ServiceInstance instance;
+
+        @BeforeEach
+        void setUp() {
+            instance = ServiceInstance.builder()
+                    .ports(List.of(
+                            Port.of(9090, PortType.APPLICATION, Security.NOT_SECURE),
+                            Port.of(9091, PortType.APPLICATION, Security.SECURE),
+                            Port.of(9190, PortType.ADMIN, Security.NOT_SECURE),
+                            Port.of(9191, PortType.ADMIN, Security.SECURE)
+                    ))
+                    .build();
+        }
+
+        @Test
+        void shouldGetApplicationPort_PreferringSecure() {
+            assertThat(instance.getApplicationPort())
+                    .isEqualTo(Port.of(9091, PortType.APPLICATION, Security.SECURE));
+        }
+
+        @Test
+        void shouldGetAdminPort_PreferringSecure() {
+            assertThat(instance.getAdminPort())
+                    .isEqualTo(Port.of(9191, PortType.ADMIN, Security.SECURE));
+        }
+    }
+
 }


### PR DESCRIPTION
* Add getApplicationPort and getAdminPort to ServiceInstance
* Make Port be a Lombok value class instead of just having getters and
  toString()

Closes #101