### PR TITLE
Allow setting List of Eureka server URLS on EurekaConfig

### DIFF
--- a/src/main/java/org/kiwiproject/registry/eureka/config/EurekaConfig.java
+++ b/src/main/java/org/kiwiproject/registry/eureka/config/EurekaConfig.java
@@ -4,11 +4,13 @@ import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.kiwiproject.net.KiwiUrls.replaceDomainsIn;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 
 import javax.validation.constraints.NotBlank;
+import java.util.List;
 
 @Getter
 @Setter
@@ -16,8 +18,25 @@ import javax.validation.constraints.NotBlank;
 public class EurekaConfig {
 
     /**
-     * A comma separated list of urls pointing to Eureka servers
+     * A comma separated list of urls pointing to Eureka servers.
+     * <p>
+     * In YAML or JSON configuration, this supports specifying as a CSV string or as a list/array of strings.
+     * <p>
+     * For example in YAML as a CSV string.
+     *
+     * <pre>
+     * registryUrls: eureka-url-1,eureka-url-2
+     * </pre>
+     * <p>
+     * Or as a list/array (also YAML):
+     *
+     * <pre>
+     * registryUrls:
+     *   - eureka-url-1
+     *   - eureka-url-2
+     * </pre>
      */
+    @JsonDeserialize(using = ListToCsvStringDeserializer.class)
     protected String registryUrls;
 
     /**
@@ -31,11 +50,33 @@ public class EurekaConfig {
      */
     private boolean includeNativeData;
 
+    /**
+     * @return comma separated list of urls pointing to Eureka servers, with domains replaced if {@code domainOverride}
+     * is set
+     */
     @NotBlank
     public String getRegistryUrls() {
         var adjustedUrls = isBlank(domainOverride) ? registryUrls : replaceDomainsIn(registryUrls, domainOverride);
         logWarningIfDomainOverrideIsSet();
         return adjustedUrls;
+    }
+
+    /**
+     * Set the comma-separate list of Eureka server URLs.
+     *
+     * @param urlCsv a string containing the CSV string containing Eureka server URLs
+     */
+    public void setRegistryUrls(String urlCsv) {
+        this.registryUrls = urlCsv;
+    }
+
+    /**
+     * Convenience method to set Eureka server URLS from a list of URLs rather than a CSV string.
+     *
+     * @param urls the list of URLs to set
+     */
+    public void setRegistryUrls(List<String> urls) {
+        this.registryUrls = String.join(",", urls);
     }
 
     private void logWarningIfDomainOverrideIsSet() {

--- a/src/main/java/org/kiwiproject/registry/eureka/config/ListToCsvStringDeserializer.java
+++ b/src/main/java/org/kiwiproject/registry/eureka/config/ListToCsvStringDeserializer.java
@@ -1,0 +1,65 @@
+package org.kiwiproject.registry.eureka.config;
+
+import static com.google.common.base.Verify.verify;
+import static java.util.stream.Collectors.joining;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.TreeNode;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.node.TextNode;
+
+import java.io.IOException;
+import java.util.stream.IntStream;
+
+/**
+ * Custom Jackson {@link JsonDeserializer} to examine a node and take different action based on whether it is
+ * a {@link TextNode} or a container node. If it is a TextNode, return the node's text, otherwise collect the
+ * values in the container and join them into a CSV string.
+ * <p>
+ * This implementation does not perform extensive error checking; it assumes the element being deserialized
+ * contains either a TextNode or is a container of TextNode. For example, as a TextNode in YAML:
+ *
+ * <pre>
+ * someProperty: value1,value2,value3
+ * </pre>
+ * <p>
+ * And as a container node:
+ *
+ * <pre>
+ * someProperty:
+ *   - value1
+ *   - value2
+ *   - value3
+ * </pre>
+ */
+class ListToCsvStringDeserializer extends JsonDeserializer<String> {
+
+    @Override
+    public String deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+        var treeNode = p.getCodec().readTree(p);
+
+        if (treeNode.isContainerNode()) {
+            return containerNodeToCsvString(treeNode);
+        }
+
+        return verifyIsTextNode(treeNode).asText();
+    }
+
+    private static String containerNodeToCsvString(TreeNode treeNode) {
+        return IntStream.range(0, treeNode.size())
+                .mapToObj(index -> textNodeToString(treeNode, index))
+                .collect(joining(","));
+    }
+
+    private static String textNodeToString(TreeNode treeNode, int index) {
+        var node = treeNode.get(index);
+        return verifyIsTextNode(node).asText();
+    }
+
+    private static TextNode verifyIsTextNode(TreeNode node) {
+        verify(node instanceof TextNode, "expected node to be TextNode but was: %s", node.getClass().getName());
+        //noinspection ConstantConditions
+        return (TextNode) node;
+    }
+}

--- a/src/test/java/org/kiwiproject/registry/eureka/config/EurekaConfigTest.java
+++ b/src/test/java/org/kiwiproject/registry/eureka/config/EurekaConfigTest.java
@@ -2,9 +2,16 @@ package org.kiwiproject.registry.eureka.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import lombok.Getter;
+import lombok.Setter;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.kiwiproject.json.JsonHelper;
+import org.kiwiproject.test.util.Fixtures;
+import org.kiwiproject.yaml.YamlHelper;
+
+import java.util.List;
 
 @DisplayName("EurekaConfig")
 class EurekaConfigTest {
@@ -17,7 +24,8 @@ class EurekaConfigTest {
             var config = new EurekaConfig();
             config.setRegistryUrls("http://eureka.test:8761/eureka,http://eureka2.test:8761/eureka");
 
-            assertThat(config.getRegistryUrls()).isEqualTo("http://eureka.test:8761/eureka,http://eureka2.test:8761/eureka");
+            assertThat(config.getRegistryUrls())
+                    .isEqualTo("http://eureka.test:8761/eureka,http://eureka2.test:8761/eureka");
         }
 
         @Test
@@ -26,7 +34,8 @@ class EurekaConfigTest {
             config.setRegistryUrls("http://eureka.test:8761/eureka,http://eureka2.test:8761/eureka");
             config.setDomainOverride("prod");
 
-            assertThat(config.getRegistryUrls()).isEqualTo("http://eureka.prod:8761/eureka,http://eureka2.prod:8761/eureka");
+            assertThat(config.getRegistryUrls())
+                    .isEqualTo("http://eureka.prod:8761/eureka,http://eureka2.prod:8761/eureka");
         }
     }
 
@@ -41,5 +50,103 @@ class EurekaConfigTest {
     void shouldDefaultIncludeNativeDataToFalse() {
         var config = new EurekaConfig();
         assertThat(config.isIncludeNativeData()).isFalse();
+    }
+
+    @Nested
+    class SetRegistryUrls {
+
+        // Tests degenerate condition; when validated registryUrls will fail the @NotBlank validation
+        @Test
+        void shouldSetFromEmptyList() {
+            var config = new EurekaConfig();
+            config.setRegistryUrls(List.of());
+
+            assertThat(config.getRegistryUrls()).isEmpty();
+        }
+
+        @Test
+        void shouldSetFromSingleElementList() {
+            var config = new EurekaConfig();
+            config.setRegistryUrls(List.of("https://eureka-001.test:8761"));
+
+            assertThat(config.getRegistryUrls()).isEqualTo("https://eureka-001.test:8761");
+        }
+
+        @Test
+        void shouldSetFromList() {
+            var config = new EurekaConfig();
+            config.setRegistryUrls(List.of(
+                    "https://eureka-1.test:8761",
+                    "https://eureka-2.test:8761"
+            ));
+
+            assertThat(config.getRegistryUrls())
+                    .isEqualTo("https://eureka-1.test:8761,https://eureka-2.test:8761");
+        }
+
+        @Nested
+        class FromYaml {
+
+            @Test
+            void shouldSetFromCsv() {
+                var yaml = Fixtures.fixture("EurekaConfigTest/sample-config-csv-urls.yml");
+                parseYamlAndAssertRegistryUrls(yaml);
+            }
+
+            @Test
+            void shouldSetFromList() {
+                var yaml = Fixtures.fixture("EurekaConfigTest/sample-config-list-of-urls.yml");
+                parseYamlAndAssertRegistryUrls(yaml);
+            }
+
+            private void parseYamlAndAssertRegistryUrls(String yaml) {
+                var sampleConfig = parseYaml(yaml);
+                assertParsedRegistryUrls(sampleConfig);
+            }
+
+            @Test
+            void shouldSetFromSingleElementList() {
+                var yaml = Fixtures.fixture("EurekaConfigTest/sample-config-list-of-one-url.yml");
+                var sampleConfig = parseYaml(yaml);
+                assertThat(sampleConfig.getEurekaConfig().getRegistryUrls())
+                        .isEqualTo("https://eureka-1.acme.com:8761");
+            }
+
+            private SampleConfig parseYaml(String yaml) {
+                return new YamlHelper().toObject(yaml, SampleConfig.class);
+            }
+        }
+
+        @Nested
+        class FromJson {
+
+            @Test
+            void shouldSetFromCsv() {
+                var json = Fixtures.fixture("EurekaConfigTest/sample-config-csv-urls.json");
+                parseJsonAndAssertRegistryUrls(json);
+            }
+
+            @Test
+            void shouldSetFromList() {
+                var json = Fixtures.fixture("EurekaConfigTest/sample-config-list-of-urls.json");
+                parseJsonAndAssertRegistryUrls(json);
+            }
+
+            private void parseJsonAndAssertRegistryUrls(String json) {
+                var sampleConfig = new JsonHelper().toObject(json, SampleConfig.class);
+                assertParsedRegistryUrls(sampleConfig);
+            }
+        }
+
+        private void assertParsedRegistryUrls(SampleConfig sampleConfig) {
+            assertThat(sampleConfig.getEurekaConfig().getRegistryUrls())
+                    .isEqualTo("https://eureka-1.acme.com:8761,https://eureka-2.acme.com:8761");
+        }
+    }
+
+    @Getter
+    @Setter
+    static class SampleConfig {
+        private EurekaConfig eurekaConfig;
     }
 }

--- a/src/test/resources/EurekaConfigTest/sample-config-csv-urls.json
+++ b/src/test/resources/EurekaConfigTest/sample-config-csv-urls.json
@@ -1,0 +1,5 @@
+{
+  "eurekaConfig": {
+    "registryUrls": "https://eureka-1.acme.com:8761,https://eureka-2.acme.com:8761"
+  }
+}

--- a/src/test/resources/EurekaConfigTest/sample-config-csv-urls.yml
+++ b/src/test/resources/EurekaConfigTest/sample-config-csv-urls.yml
@@ -1,0 +1,4 @@
+---
+
+eurekaConfig:
+  registryUrls: https://eureka-1.acme.com:8761,https://eureka-2.acme.com:8761

--- a/src/test/resources/EurekaConfigTest/sample-config-list-of-one-url.yml
+++ b/src/test/resources/EurekaConfigTest/sample-config-list-of-one-url.yml
@@ -1,0 +1,5 @@
+---
+
+eurekaConfig:
+  registryUrls:
+    - https://eureka-1.acme.com:8761

--- a/src/test/resources/EurekaConfigTest/sample-config-list-of-urls.json
+++ b/src/test/resources/EurekaConfigTest/sample-config-list-of-urls.json
@@ -1,0 +1,8 @@
+{
+  "eurekaConfig": {
+    "registryUrls": [
+      "https://eureka-1.acme.com:8761",
+      "https://eureka-2.acme.com:8761"
+    ]
+  }
+}

--- a/src/test/resources/EurekaConfigTest/sample-config-list-of-urls.yml
+++ b/src/test/resources/EurekaConfigTest/sample-config-list-of-urls.yml
@@ -1,0 +1,6 @@
+---
+
+eurekaConfig:
+  registryUrls:
+    - https://eureka-1.acme.com:8761
+    - https://eureka-2.acme.com:8761


### PR DESCRIPTION
* Add setRegistryUrls(List<String>) in EurekaConfig
* Add "default" setRegistryUrls(String) in EurekaConfig because Lombok
  no longer generates the setter once it sees that there already is one
* Add ListToCsvStringDeserializer, a custom Jackson JsonDeserializer to
  allow de-serialization from either a CSV string or a list of strings
* Add a bunch of YAML and JSON test resources to support testing the
  various de-serialization cases

Closes #103