### PR TITLE
Fix compile errors due to embedded-eureka updates; misc cleanup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
         <metrics-jetty9.version>4.1.18</metrics-jetty9.version>
         <metrics-servlet.version>4.1.18</metrics-servlet.version>
         <okhttp.version>3.12.2</okhttp.version>
-        <re-retrying.version>3.0.0</re-retrying.version>
+        <retrying-again.version>0.5.0</retrying-again.version>
 
         <!-- Versions for optional dependencies -->
 
@@ -69,6 +69,12 @@
             <groupId>org.kiwiproject</groupId>
             <artifactId>kiwi</artifactId>
             <version>${kiwi.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.kiwiproject</groupId>
+            <artifactId>retrying-again</artifactId>
+            <version>${retrying-again.version}</version>
         </dependency>
 
         <!-- Provided dependencies -->
@@ -201,19 +207,6 @@
                 <exclusion>
                     <groupId>org.glassfish.jersey.core</groupId>
                     <artifactId>jersey-server</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-
-        <dependency>
-            <groupId>tech.huffman.re-retrying</groupId>
-            <artifactId>re-retrying</artifactId>
-            <version>${re-retrying.version}</version>
-            <scope>provided</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.google.guava</groupId>
-                    <artifactId>guava</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/src/main/java/org/kiwiproject/registry/eureka/client/EurekaRegistryClient.java
+++ b/src/main/java/org/kiwiproject/registry/eureka/client/EurekaRegistryClient.java
@@ -11,10 +11,7 @@ import static org.kiwiproject.retry.KiwiRetryerPredicates.SOCKET_TIMEOUT;
 import static org.kiwiproject.retry.KiwiRetryerPredicates.SSL_HANDSHAKE_ERROR;
 import static org.kiwiproject.retry.KiwiRetryerPredicates.UNKNOWN_HOST;
 
-import com.github.rholder.retry.WaitStrategies;
-import com.github.rholder.retry.WaitStrategy;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Predicate;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.kiwiproject.jaxrs.KiwiGenericTypes;
@@ -27,12 +24,15 @@ import org.kiwiproject.registry.eureka.config.EurekaConfig;
 import org.kiwiproject.registry.model.NativeRegistryData;
 import org.kiwiproject.registry.model.ServiceInstance;
 import org.kiwiproject.retry.KiwiRetryer;
+import org.kiwiproject.retry.WaitStrategies;
+import org.kiwiproject.retry.WaitStrategy;
 
 import javax.ws.rs.ServerErrorException;
 import javax.ws.rs.core.Response;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
 
 /**
  * {@link RegistryClient} implementation for looking up services from Eureka registry server.
@@ -69,8 +69,7 @@ public class EurekaRegistryClient implements RegistryClient {
         this.config = config;
     }
 
-    @SuppressWarnings({"Guava"}) // the KiwiRetryer uses guava-retrying under the hood
-    private static Predicate<Throwable> temporaryServerSideStatusCodes() {
+    private static Predicate<Exception> temporaryServerSideStatusCodes() {
         return t -> {
             if (t instanceof ServerErrorException) {
                 return checkIfDesiredStatusCodeValueIsFoundIn((ServerErrorException) t);

--- a/src/test/java/org/kiwiproject/registry/eureka/common/EurekaRestClientTest.java
+++ b/src/test/java/org/kiwiproject/registry/eureka/common/EurekaRestClientTest.java
@@ -41,7 +41,7 @@ class EurekaRestClientTest {
 
     @AfterEach
     void cleanupEureka() {
-        EUREKA.getEurekaServer().getRegistry().cleanupApps();
+        EUREKA.clearRegisteredApps();
     }
 
     @Nested
@@ -75,8 +75,7 @@ class EurekaRestClientTest {
 
         @Test
         void shouldReturnResponseFromEurekaWhenFound() {
-            var eurekaRegistry = EUREKA.getEurekaServer().getRegistry();
-            eurekaRegistry.registerApplication("APPID", "INSTANCEID", "FOO-SERVICE", "UP");
+            EUREKA.registerApplication("APPID", "INSTANCEID", "FOO-SERVICE", "UP");
 
             var response = client.findInstance(eurekaBaseUrl, "APPID", "INSTANCEID");
 
@@ -96,8 +95,7 @@ class EurekaRestClientTest {
 
         @Test
         void shouldReturnResponseFromEurekaWhenFound() {
-            var eurekaRegistry = EUREKA.getEurekaServer().getRegistry();
-            eurekaRegistry.registerApplication("APPID", "INSTANCEID", "FOO", "UP");
+            EUREKA.registerApplication("APPID", "INSTANCEID", "FOO", "UP");
 
             var response = client.findInstancesByVipAddress(eurekaBaseUrl, "FOO");
 
@@ -111,14 +109,13 @@ class EurekaRestClientTest {
 
         @Test
         void shouldReturnResponseFromEureka() {
-            var eurekaRegistry = EUREKA.getEurekaServer().getRegistry();
-            eurekaRegistry.registerApplication("APPID", "INSTANCEID", "FOO", "DOWN");
+            EUREKA.registerApplication("APPID", "INSTANCEID", "FOO", "DOWN");
 
             var response = client.updateStatus(eurekaBaseUrl, "APPID", "INSTANCEID", ServiceInstance.Status.UP);
 
             assertOkResponse(response);
 
-            var instance = eurekaRegistry.getRegisteredApplication("APPID").getByInstanceId("INSTANCEID");
+            var instance = EUREKA.getRegisteredApplication("APPID").getByInstanceId("INSTANCEID");
             assertThat(instance.getStatus()).isEqualTo(InstanceInfo.InstanceStatus.UP);
         }
 
@@ -129,13 +126,12 @@ class EurekaRestClientTest {
 
         @Test
         void shouldReturnResponseFromEureka() {
-            var eurekaRegistry = EUREKA.getEurekaServer().getRegistry();
-            eurekaRegistry.registerApplication("APPID", "INSTANCEID", "FOO", "UP");
+            EUREKA.registerApplication("APPID", "INSTANCEID", "FOO", "UP");
 
             var response = client.unregister(eurekaBaseUrl, "APPID", "INSTANCEID");
 
             assertOkResponse(response);
-            assertThat(eurekaRegistry.isApplicationRegistered("APPID")).isFalse();
+            assertThat(EUREKA.isApplicationRegistered("APPID")).isFalse();
         }
 
     }
@@ -145,14 +141,13 @@ class EurekaRestClientTest {
 
         @Test
         void shouldReturnResponseFromEureka() {
-            var eurekaRegistry = EUREKA.getEurekaServer().getRegistry();
-            eurekaRegistry.registerApplication("APPID", "INSTANCEID", "FOO", "UP");
+            EUREKA.registerApplication("APPID", "INSTANCEID", "FOO", "UP");
 
             var response = client.sendHeartbeat(eurekaBaseUrl, "APPID", "INSTANCEID");
 
             assertOkResponse(response);
 
-            assertThat(eurekaRegistry.getHeartbeatCount()).isOne();
+            assertThat(EUREKA.getHeartbeatCount()).isOne();
         }
 
     }
@@ -162,8 +157,7 @@ class EurekaRestClientTest {
 
         @Test
         void shouldReturnResponseFromEureka() {
-            var eurekaRegistry = EUREKA.getEurekaServer().getRegistry();
-            eurekaRegistry.registerApplication("APPID", "INSTANCEID", "FOO", "UP");
+            EUREKA.registerApplication("APPID", "INSTANCEID", "FOO", "UP");
 
             var response = client.findAllInstances(eurekaBaseUrl);
 


### PR DESCRIPTION
* Fix the compile errors that occurred when updating to embedded-eureka
  0.12.0, specifically registeredApplications() was renamed to
  getRegisteredApplications() and cleanupApps() method was renamed to
  clearRegisteredApps().
* Switch from re-retrying library to retrying-again since that changed
  in kiwi 0.21.0, and fix various breaking changes such as
  KiwiRetryerPredicates now using Exception not Throwable, and using
  the Java/JDK Predicate instead of Guava's.
* Fix breaking test in EurekaRegistryClientTest due to the switch to
  retrying-again; Retryer no longer throws an ExecutionException so
  the cause of the KiwiRetryerException should be RetryException
* Use the helper methods now in EurekaServerExtension as of
  embedded-eureka 0.12.0 to avoid all the repeated calls to
  getEurekaServer().getRegistry()

Closes #105
Closes #111 