### PR TITLE
Fix Eureka status url from `statusUrl` to `statusPageUrl` (#115)

### DIFF
--- a/src/main/java/org/kiwiproject/registry/eureka/client/EurekaParser.java
+++ b/src/main/java/org/kiwiproject/registry/eureka/client/EurekaParser.java
@@ -74,7 +74,7 @@ class EurekaParser {
 
         Map<String, Object> leaseInfo = extractLeaseInfo(leaseInfoMap);
 
-        var statusUrl = getStringOrNull(instanceData, "statusUrl");
+        var statusUrl = getStringOrNull(instanceData, "statusPageUrl");
         var healthCheckUrl = getStringOrNull(instanceData, "healthCheckUrl");
         var url = firstNonNullOrNull(statusUrl, healthCheckUrl);
         var adminPort = getAdminPort(url);

--- a/src/test/resources/EurekaParserTest/eureka-response-as-all-lists.json
+++ b/src/test/resources/EurekaParserTest/eureka-response-as-all-lists.json
@@ -12,7 +12,7 @@
             "status": "UP",
             "homePageUrl": "http://localhost",
             "healthCheckUrl": "http://localhost/healthcheck",
-            "statusUrl": "http://localhost/ping",
+            "statusPageUrl": "http://localhost/ping",
             "port": {
               "$": 8080,
               "@enabled": true

--- a/src/test/resources/EurekaParserTest/eureka-response-as-all-maps.json
+++ b/src/test/resources/EurekaParserTest/eureka-response-as-all-maps.json
@@ -10,7 +10,7 @@
         "status": "UP",
         "homePageUrl": "http://localhost",
         "healthCheckUrl": "http://localhost/healthcheck",
-        "statusUrl": "http://localhost/ping",
+        "statusPageUrl": "http://localhost/ping",
         "port": {
           "$": 8080,
           "@enabled": true

--- a/src/test/resources/EurekaParserTest/eureka-response-as-application-list-instance-map.json
+++ b/src/test/resources/EurekaParserTest/eureka-response-as-application-list-instance-map.json
@@ -11,7 +11,7 @@
           "status": "UP",
           "homePageUrl": "http://localhost",
           "healthCheckUrl": "http://localhost/healthcheck",
-          "statusUrl": "http://localhost/ping",
+          "statusPageUrl": "http://localhost/ping",
           "port": {
             "$": 8080,
             "@enabled": true

--- a/src/test/resources/EurekaParserTest/eureka-response-as-application-map-instance-list.json
+++ b/src/test/resources/EurekaParserTest/eureka-response-as-application-map-instance-list.json
@@ -11,7 +11,7 @@
           "status": "UP",
           "homePageUrl": "http://localhost",
           "healthCheckUrl": "http://localhost/healthcheck",
-          "statusUrl": "http://localhost/ping",
+          "statusPageUrl": "http://localhost/ping",
           "port": {
             "$": 8080,
             "@enabled": true


### PR DESCRIPTION
* Fix Eureka status url from `statusUrl` to `statusPageUrl`

Closes #113