### PR TITLE
Remove redundant warning suppression annotations

### DIFF
--- a/src/main/java/org/kiwiproject/registry/eureka/client/EurekaParser.java
+++ b/src/main/java/org/kiwiproject/registry/eureka/client/EurekaParser.java
@@ -112,7 +112,6 @@ class EurekaParser {
         return Map.of();
     }
 
-    @SuppressWarnings("ConstantConditions")
     private static <K> String getStringOrNull(final Map<? super K, ?> map, final K key) {
         var value = map.getOrDefault(key, null);
 

--- a/src/main/java/org/kiwiproject/registry/eureka/config/ListToCsvStringDeserializer.java
+++ b/src/main/java/org/kiwiproject/registry/eureka/config/ListToCsvStringDeserializer.java
@@ -59,7 +59,6 @@ class ListToCsvStringDeserializer extends JsonDeserializer<String> {
 
     private static TextNode verifyIsTextNode(TreeNode node) {
         verify(node instanceof TextNode, "expected node to be TextNode but was: %s", node.getClass().getName());
-        //noinspection ConstantConditions
         return (TextNode) node;
     }
 }

--- a/src/main/java/org/kiwiproject/registry/model/ServicePaths.java
+++ b/src/main/java/org/kiwiproject/registry/model/ServicePaths.java
@@ -8,7 +8,7 @@ import lombok.Getter;
  */
 @Builder
 @Getter
-@SuppressWarnings({"java:S1075", "FieldMayBeFinal"})
+@SuppressWarnings({"java:S1075"})  // Sonar S1075: URIs should not be hardcoded
 public class ServicePaths {
 
     /**

--- a/src/test/java/org/kiwiproject/registry/eureka/client/EurekaParserTest.java
+++ b/src/test/java/org/kiwiproject/registry/eureka/client/EurekaParserTest.java
@@ -86,7 +86,6 @@ class EurekaParserTest {
         assertEurekaInstance(parsedData, softly);
     }
 
-    @SuppressWarnings("unchecked")
     private void assertEurekaInstance(EurekaInstance instance, SoftAssertions softly) {
         softly.assertThat(instance.getInstanceId()).isEqualTo("localhost");
         softly.assertThat(instance.getApp()).isEqualTo("TEST-SERVICE");

--- a/src/test/java/org/kiwiproject/registry/eureka/common/EurekaInstanceTest.java
+++ b/src/test/java/org/kiwiproject/registry/eureka/common/EurekaInstanceTest.java
@@ -29,7 +29,6 @@ class EurekaInstanceTest {
     @Nested
     class FromServiceInstance {
 
-        @SuppressWarnings("unchecked")
         @Test
         void shouldReturnNewInstanceWhenOnlyNonSecurePorts(SoftAssertions softly) {
             var service = ServiceInstance.fromServiceInfo(ServiceInfoHelper.buildTestServiceInfo()).withStatus(ServiceInstance.Status.STARTING);

--- a/src/test/java/org/kiwiproject/registry/model/ServicePathsTest.java
+++ b/src/test/java/org/kiwiproject/registry/model/ServicePathsTest.java
@@ -16,4 +16,17 @@ class ServicePathsTest {
         assertThat(paths.getStatusPath()).isEqualTo(ServicePaths.DEFAULT_STATUS_PATH);
         assertThat(paths.getHealthCheckPath()).isEqualTo(ServicePaths.DEFAULT_HEALTHCHECK_PATH);
     }
+
+    @Test
+    void shouldAllowCustomPaths() {
+        var paths = ServicePaths.builder()
+                .homePagePath("/myhome")
+                .statusPath("/mystatus")
+                .healthCheckPath("/myhealth")
+                .build();
+
+        assertThat(paths.getHomePagePath()).isEqualTo("/myhome");
+        assertThat(paths.getStatusPath()).isEqualTo("/mystatus");
+        assertThat(paths.getHealthCheckPath()).isEqualTo("/myhealth");
+    }
 }


### PR DESCRIPTION
* Remove redundant SuppressWarnings annotations and code comments
  (which I guess IntelliJ now understands)
* Added silly test to ServicePathsTest (in case we ever remove Lombok)