### PR TITLE
Sonar: fix deprecated code usage in RegistrationLifecycleListener

### DIFF
--- a/src/main/java/org/kiwiproject/registry/management/dropwizard/RegistrationLifecycleListener.java
+++ b/src/main/java/org/kiwiproject/registry/management/dropwizard/RegistrationLifecycleListener.java
@@ -6,7 +6,6 @@ import io.dropwizard.lifecycle.PortDescriptor;
 import io.dropwizard.lifecycle.ServerLifecycleListener;
 import lombok.extern.slf4j.Slf4j;
 import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.util.component.AbstractLifeCycle;
 import org.eclipse.jetty.util.component.LifeCycle;
 import org.kiwiproject.registry.config.ServiceInfo;
 import org.kiwiproject.registry.management.RegistrationManager;
@@ -19,10 +18,10 @@ import java.util.List;
 import java.util.Optional;
 
 /**
- * Listener that registers and deregisters the service based on server start up and shutdown events.
+ * Listener that registers and de-registers the service based on server start up and shutdown events.
  * <p>
  * Note: This class implements the {@link ServerLifecycleListener} which is part of Dropwizard to provide access once Dropwizard has finished starting
- * the server.  This class also extends {@link AbstractLifeCycle.AbstractLifeCycleListener} from Jetty (which Dropwizard uses under the covers) to provide
+ * the server.  This class also extends {@link LifeCycle.Listener} from Jetty (which Dropwizard uses under the covers) to provide
  * access when the server is starting to shut down.  To use this class you may have to register this listener in the following ways to get both actions:
  * <pre>
  *  var listener = new RegistrationLifecycleListener(manager);
@@ -35,7 +34,7 @@ import java.util.Optional;
  * </pre>
  */
 @Slf4j
-public class RegistrationLifecycleListener extends AbstractLifeCycle.AbstractLifeCycleListener implements ServerLifecycleListener {
+public class RegistrationLifecycleListener implements LifeCycle.Listener, ServerLifecycleListener {
 
     private final RegistrationManager registrationManager;
 
@@ -52,8 +51,8 @@ public class RegistrationLifecycleListener extends AbstractLifeCycle.AbstractLif
      * Creates a new listener with a given {@link ServiceInfo} and {@link RegistryService}.  This will create the {@link RegistrationManager} that will
      * be used to register the service.
      *
-     * @param serviceInfo       the {@link ServiceInfo} to use for registering the service
-     * @param registryService   the {@link RegistryService} to use for sending the registration
+     * @param serviceInfo     the {@link ServiceInfo} to use for registering the service
+     * @param registryService the {@link RegistryService} to use for sending the registration
      */
     public RegistrationLifecycleListener(ServiceInfo serviceInfo, RegistryService registryService) {
         this.registrationManager = new RegistrationManager(serviceInfo, registryService);
@@ -93,7 +92,7 @@ public class RegistrationLifecycleListener extends AbstractLifeCycle.AbstractLif
         return portProtocol.map(protocol -> Port.of(port, portType, Security.fromScheme(protocol)));
     }
 
-    // This method comes from AbstractLifeCycle.AbstractLifeCycleListener
+    // This method comes from LifeCycle.Listener
     @Override
     public void lifeCycleStopping(LifeCycle event) {
         try {


### PR DESCRIPTION
Change RegistrationLifecycleListener to implement Lifecycle.Listener
instead of extending AbstractLifeCycle.AbstractLifeCycleListener, which
is deprecated.