### PR TITLE
Switch to test containers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,6 @@
         <retrying-again.version>1.0.9</retrying-again.version>
 
         <!-- Versions for test dependencies -->
-        <embedded-eureka.version>1.0.7</embedded-eureka.version>
         <kiwi-test.version>2.1.0</kiwi-test.version>
         <test-containers.version>1.17.3</test-containers.version>
 
@@ -108,13 +107,6 @@
         <dependency>
             <groupId>com.pszymczyk.consul</groupId>
             <artifactId>embedded-consul</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.kiwiproject</groupId>
-            <artifactId>embedded-eureka</artifactId>
-            <version>${embedded-eureka.version}</version>
             <scope>test</scope>
         </dependency>
         

--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,7 @@
         <!-- Versions for test dependencies -->
         <embedded-eureka.version>1.0.7</embedded-eureka.version>
         <kiwi-test.version>2.1.0</kiwi-test.version>
+        <test-containers.version>1.17.3</test-containers.version>
 
         <!-- Sonar properties -->
         <sonar.projectKey>kiwiproject_service-discovery-client</sonar.projectKey>
@@ -120,6 +121,20 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <version>${test-containers.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${test-containers.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/src/main/java/org/kiwiproject/registry/eureka/client/EurekaRegistryClient.java
+++ b/src/main/java/org/kiwiproject/registry/eureka/client/EurekaRegistryClient.java
@@ -143,7 +143,6 @@ public class EurekaRegistryClient implements RegistryClient {
             return List.of();
         }
 
-        LOG.info("Headers: {}", response.getHeaders());
         return parseEurekaInstances(response);
     }
 
@@ -170,7 +169,6 @@ public class EurekaRegistryClient implements RegistryClient {
             return List.of();
         }
 
-        LOG.info("Headers: {}", response.getHeaders());
         var eurekaInstances = parseEurekaInstances(response);
 
         var includeNativeData = config.isIncludeNativeData()

--- a/src/main/java/org/kiwiproject/registry/eureka/client/EurekaRegistryClient.java
+++ b/src/main/java/org/kiwiproject/registry/eureka/client/EurekaRegistryClient.java
@@ -11,10 +11,15 @@ import static org.kiwiproject.retry.KiwiRetryerPredicates.SOCKET_TIMEOUT;
 import static org.kiwiproject.retry.KiwiRetryerPredicates.SSL_HANDSHAKE_ERROR;
 import static org.kiwiproject.retry.KiwiRetryerPredicates.UNKNOWN_HOST;
 
-import com.google.common.annotations.VisibleForTesting;
-import lombok.extern.slf4j.Slf4j;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
+
+import javax.ws.rs.ServerErrorException;
+import javax.ws.rs.core.Response;
+
 import org.apache.commons.lang3.exception.ExceptionUtils;
-import org.kiwiproject.jaxrs.KiwiEntities;
 import org.kiwiproject.jaxrs.KiwiGenericTypes;
 import org.kiwiproject.registry.client.RegistryClient;
 import org.kiwiproject.registry.client.ServiceInstanceFilter;
@@ -29,12 +34,9 @@ import org.kiwiproject.retry.KiwiRetryer;
 import org.kiwiproject.retry.WaitStrategies;
 import org.kiwiproject.retry.WaitStrategy;
 
-import javax.ws.rs.ServerErrorException;
-import javax.ws.rs.core.Response;
-import java.util.List;
-import java.util.Optional;
-import java.util.concurrent.TimeUnit;
-import java.util.function.Predicate;
+import com.google.common.annotations.VisibleForTesting;
+
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * {@link RegistryClient} implementation for looking up services from Eureka registry server.

--- a/src/main/java/org/kiwiproject/registry/eureka/client/EurekaRegistryClient.java
+++ b/src/main/java/org/kiwiproject/registry/eureka/client/EurekaRegistryClient.java
@@ -11,14 +11,8 @@ import static org.kiwiproject.retry.KiwiRetryerPredicates.SOCKET_TIMEOUT;
 import static org.kiwiproject.retry.KiwiRetryerPredicates.SSL_HANDSHAKE_ERROR;
 import static org.kiwiproject.retry.KiwiRetryerPredicates.UNKNOWN_HOST;
 
-import java.util.List;
-import java.util.Optional;
-import java.util.concurrent.TimeUnit;
-import java.util.function.Predicate;
-
-import javax.ws.rs.ServerErrorException;
-import javax.ws.rs.core.Response;
-
+import com.google.common.annotations.VisibleForTesting;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.kiwiproject.jaxrs.KiwiGenericTypes;
 import org.kiwiproject.registry.client.RegistryClient;
@@ -34,9 +28,12 @@ import org.kiwiproject.retry.KiwiRetryer;
 import org.kiwiproject.retry.WaitStrategies;
 import org.kiwiproject.retry.WaitStrategy;
 
-import com.google.common.annotations.VisibleForTesting;
-
-import lombok.extern.slf4j.Slf4j;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
+import javax.ws.rs.ServerErrorException;
+import javax.ws.rs.core.Response;
 
 /**
  * {@link RegistryClient} implementation for looking up services from Eureka registry server.

--- a/src/main/java/org/kiwiproject/registry/eureka/client/EurekaRegistryClient.java
+++ b/src/main/java/org/kiwiproject/registry/eureka/client/EurekaRegistryClient.java
@@ -14,6 +14,7 @@ import static org.kiwiproject.retry.KiwiRetryerPredicates.UNKNOWN_HOST;
 import com.google.common.annotations.VisibleForTesting;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.kiwiproject.jaxrs.KiwiEntities;
 import org.kiwiproject.jaxrs.KiwiGenericTypes;
 import org.kiwiproject.registry.client.RegistryClient;
 import org.kiwiproject.registry.client.ServiceInstanceFilter;
@@ -143,6 +144,7 @@ public class EurekaRegistryClient implements RegistryClient {
             return List.of();
         }
 
+        LOG.info("Headers: {}", response.getHeaders());
         return parseEurekaInstances(response);
     }
 
@@ -169,6 +171,7 @@ public class EurekaRegistryClient implements RegistryClient {
             return List.of();
         }
 
+        LOG.info("Headers: {}", response.getHeaders());
         var eurekaInstances = parseEurekaInstances(response);
 
         var includeNativeData = config.isIncludeNativeData()

--- a/src/main/java/org/kiwiproject/registry/eureka/common/EurekaRestClient.java
+++ b/src/main/java/org/kiwiproject/registry/eureka/common/EurekaRestClient.java
@@ -7,12 +7,13 @@ import static javax.ws.rs.core.MediaType.APPLICATION_JSON_TYPE;
 
 import lombok.AllArgsConstructor;
 import org.glassfish.jersey.client.ClientProperties;
+import org.glassfish.jersey.message.GZipEncoder;
 import org.kiwiproject.registry.model.ServiceInstance;
 
+import java.util.Map;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.core.Response;
-import java.util.Map;
 
 @AllArgsConstructor
 public class EurekaRestClient {
@@ -33,6 +34,7 @@ public class EurekaRestClient {
 
     private static Client newClient() {
         return ClientBuilder.newClient()
+                .register(GZipEncoder.class)
                 .property(ClientProperties.CONNECT_TIMEOUT, DEFAULT_CONNECT_TIMEOUT_MILLIS)
                 .property(ClientProperties.READ_TIMEOUT, DEFAULT_READ_TIMEOUT_MILLIS);
     }

--- a/src/main/java/org/kiwiproject/registry/eureka/config/EurekaRegistrationConfig.java
+++ b/src/main/java/org/kiwiproject/registry/eureka/config/EurekaRegistrationConfig.java
@@ -50,6 +50,6 @@ public class EurekaRegistrationConfig extends EurekaConfig {
     /**
      * Whether the registry service should track the number of heartbeats sent. Mostly used for testing purposes.
      */
-    private boolean shouldTrackHeartbeats;
+    private boolean trackHeartbeats;
 
 }

--- a/src/main/java/org/kiwiproject/registry/eureka/config/EurekaRegistrationConfig.java
+++ b/src/main/java/org/kiwiproject/registry/eureka/config/EurekaRegistrationConfig.java
@@ -47,4 +47,9 @@ public class EurekaRegistrationConfig extends EurekaConfig {
     @Max(MAX_LEASE_EXPIRATION_DURATION_SECONDS)
     private int expirationIntervalInSeconds = DEFAULT_LEASE_EXPIRATION_DURATION_SECONDS;
 
+    /**
+     * Whether the registry service should track the number of heartbeats sent. Mostly used for testing purposes.
+     */
+    private boolean shouldTrackHeartbeats;
+
 }

--- a/src/main/java/org/kiwiproject/registry/eureka/server/EurekaHeartbeatSender.java
+++ b/src/main/java/org/kiwiproject/registry/eureka/server/EurekaHeartbeatSender.java
@@ -48,6 +48,7 @@ class EurekaHeartbeatSender implements Runnable {
 
     @VisibleForTesting
     @Getter(AccessLevel.PACKAGE)
+    @Setter(AccessLevel.PACKAGE)
     private Instant heartbeatFailureStartedAt;
 
     private final Runnable heartbeatSentListener;
@@ -78,6 +79,7 @@ class EurekaHeartbeatSender implements Runnable {
         if (nonNull(response) && successful(response)) {
             logRecoveryIfNecessary();
             heartbeatFailures = 0;
+            heartbeatFailureStartedAt = null;
             heartbeatSentListener.run();
             return;
         }

--- a/src/main/java/org/kiwiproject/registry/eureka/server/EurekaHeartbeatSender.java
+++ b/src/main/java/org/kiwiproject/registry/eureka/server/EurekaHeartbeatSender.java
@@ -23,10 +23,10 @@ import org.kiwiproject.registry.eureka.common.EurekaUrlProvider;
 import org.kiwiproject.registry.model.ServiceInstance;
 import org.kiwiproject.retry.KiwiRetryerPredicates;
 
-import javax.annotation.Nullable;
-import javax.ws.rs.core.Response;
 import java.time.Duration;
 import java.time.Instant;
+import javax.annotation.Nullable;
+import javax.ws.rs.core.Response;
 
 @Slf4j
 class EurekaHeartbeatSender implements Runnable {

--- a/src/main/java/org/kiwiproject/registry/eureka/server/EurekaHeartbeatSender.java
+++ b/src/main/java/org/kiwiproject/registry/eureka/server/EurekaHeartbeatSender.java
@@ -50,11 +50,14 @@ class EurekaHeartbeatSender implements Runnable {
     @Getter(AccessLevel.PACKAGE)
     private Instant heartbeatFailureStartedAt;
 
-    EurekaHeartbeatSender(EurekaRestClient client, EurekaRegistryService registryService, EurekaInstance registeredInstance, EurekaUrlProvider urlProvider) {
+    private final Runnable heartbeatSentListener;
+
+    EurekaHeartbeatSender(EurekaRestClient client, EurekaRegistryService registryService, EurekaInstance registeredInstance, EurekaUrlProvider urlProvider, Runnable heartbeatSentListener) {
         this.client = client;
         this.registeredInstance = registeredInstance;
         this.registryService = registryService;
         this.urlProvider = urlProvider;
+        this.heartbeatSentListener = heartbeatSentListener;
     }
 
     @Override
@@ -75,6 +78,7 @@ class EurekaHeartbeatSender implements Runnable {
         if (nonNull(response) && successful(response)) {
             logRecoveryIfNecessary();
             heartbeatFailures = 0;
+            heartbeatSentListener.run();
             return;
         }
 

--- a/src/main/java/org/kiwiproject/registry/eureka/server/EurekaRegistryService.java
+++ b/src/main/java/org/kiwiproject/registry/eureka/server/EurekaRegistryService.java
@@ -31,7 +31,6 @@ import org.kiwiproject.registry.model.ServiceInstance.Status;
 import org.kiwiproject.registry.server.RegistryService;
 import org.kiwiproject.retry.SimpleRetryer;
 
-import javax.ws.rs.core.Response;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.TemporalAccessor;
@@ -46,6 +45,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.function.Supplier;
+import javax.ws.rs.core.Response;
 
 @Slf4j
 public class EurekaRegistryService implements RegistryService {

--- a/src/main/java/org/kiwiproject/registry/eureka/server/EurekaRegistryService.java
+++ b/src/main/java/org/kiwiproject/registry/eureka/server/EurekaRegistryService.java
@@ -468,6 +468,9 @@ public class EurekaRegistryService implements RegistryService {
 
     void clearRegisteredInstance() {
         registeredInstance.set(null);
+        if (heartbeatCount.get() >= 0) {
+            heartbeatCount.set(0);
+        }
     }
 
 }

--- a/src/main/java/org/kiwiproject/registry/eureka/server/EurekaRegistryService.java
+++ b/src/main/java/org/kiwiproject/registry/eureka/server/EurekaRegistryService.java
@@ -180,7 +180,7 @@ public class EurekaRegistryService implements RegistryService {
                 .retryDelayUnit(UNREGISTER_RETRY_DELAY_UNIT)
                 .build();
 
-        if (config.isShouldTrackHeartbeats()) {
+        if (config.isTrackHeartbeats()) {
             heartbeatCount = new AtomicLong(0);
         } else {
             heartbeatCount = new AtomicLong(-1);

--- a/src/main/java/org/kiwiproject/registry/eureka/server/EurekaRegistryService.java
+++ b/src/main/java/org/kiwiproject/registry/eureka/server/EurekaRegistryService.java
@@ -147,6 +147,41 @@ public class EurekaRegistryService implements RegistryService {
     private final boolean trackHeartbeats;
 
     public EurekaRegistryService(EurekaRegistrationConfig config, EurekaRestClient client, KiwiEnvironment environment) {
+        this(config,
+                client,
+                environment,
+                SimpleRetryer.builder()
+                    .environment(environment)
+                    .maxAttempts(MAX_REGISTRATION_ATTEMPTS)
+                    .retryDelayTime(RETRY_DELAY)
+                    .retryDelayUnit(RETRY_DELAY_UNIT)
+                    .build(),
+                SimpleRetryer.builder()
+                    .environment(environment)
+                    .maxAttempts(MAX_AWAIT_REGISTRATION_CONFIRMATION_TRIES)
+                    .retryDelayTime(RETRY_DELAY)
+                    .retryDelayUnit(RETRY_DELAY_UNIT)
+                    .build(),
+                SimpleRetryer.builder()
+                    .environment(environment)
+                    .maxAttempts(MAX_UPDATE_STATUS_ATTEMPTS)
+                    .retryDelayTime(RETRY_DELAY)
+                    .retryDelayUnit(RETRY_DELAY_UNIT)
+                    .build(),
+                SimpleRetryer.builder()
+                    .environment(environment)
+                    .maxAttempts(MAX_UNREGISTER_ATTEMPTS)
+                    .retryDelayTime(UNREGISTER_RETRY_DELAY)
+                    .retryDelayUnit(UNREGISTER_RETRY_DELAY_UNIT)
+                    .build());
+    }
+    public EurekaRegistryService(EurekaRegistrationConfig config,
+                                 EurekaRestClient client,
+                                 KiwiEnvironment environment,
+                                 SimpleRetryer registerRetryer,
+                                 SimpleRetryer awaitRetryer,
+                                 SimpleRetryer updateStatusRetryer,
+                                 SimpleRetryer unregisterRetryer) {
         this.config = config;
         this.client = client;
         this.environment = environment;
@@ -154,33 +189,10 @@ public class EurekaRegistryService implements RegistryService {
         this.registeredInstance = new AtomicReference<>();
         this.heartbeatExecutor = new AtomicReference<>();
 
-        this.registerRetryer = SimpleRetryer.builder()
-                .environment(environment)
-                .maxAttempts(MAX_REGISTRATION_ATTEMPTS)
-                .retryDelayTime(RETRY_DELAY)
-                .retryDelayUnit(RETRY_DELAY_UNIT)
-                .build();
-
-        this.awaitRetryer = SimpleRetryer.builder()
-                .environment(environment)
-                .maxAttempts(MAX_AWAIT_REGISTRATION_CONFIRMATION_TRIES)
-                .retryDelayTime(RETRY_DELAY)
-                .retryDelayUnit(RETRY_DELAY_UNIT)
-                .build();
-
-        this.updateStatusRetryer = SimpleRetryer.builder()
-                .environment(environment)
-                .maxAttempts(MAX_UPDATE_STATUS_ATTEMPTS)
-                .retryDelayTime(RETRY_DELAY)
-                .retryDelayUnit(RETRY_DELAY_UNIT)
-                .build();
-
-        this.unregisterRetryer = SimpleRetryer.builder()
-                .environment(environment)
-                .maxAttempts(MAX_UNREGISTER_ATTEMPTS)
-                .retryDelayTime(UNREGISTER_RETRY_DELAY)
-                .retryDelayUnit(UNREGISTER_RETRY_DELAY_UNIT)
-                .build();
+        this.registerRetryer = registerRetryer;
+        this.awaitRetryer = awaitRetryer;
+        this.updateStatusRetryer = updateStatusRetryer;
+        this.unregisterRetryer = unregisterRetryer;
 
         this.trackHeartbeats = config.isTrackHeartbeats();
 

--- a/src/main/java/org/kiwiproject/registry/eureka/server/EurekaRegistryService.java
+++ b/src/main/java/org/kiwiproject/registry/eureka/server/EurekaRegistryService.java
@@ -142,7 +142,9 @@ public class EurekaRegistryService implements RegistryService {
     final AtomicReference<ScheduledExecutorService> heartbeatExecutor;
 
     @VisibleForTesting
-    final AtomicLong heartbeatCount;
+    AtomicLong heartbeatCount;
+
+    private final boolean trackHeartbeats;
 
     public EurekaRegistryService(EurekaRegistrationConfig config, EurekaRestClient client, KiwiEnvironment environment) {
         this.config = config;
@@ -180,10 +182,10 @@ public class EurekaRegistryService implements RegistryService {
                 .retryDelayUnit(UNREGISTER_RETRY_DELAY_UNIT)
                 .build();
 
-        if (config.isTrackHeartbeats()) {
+        this.trackHeartbeats = config.isTrackHeartbeats();
+
+        if (trackHeartbeats) {
             heartbeatCount = new AtomicLong(0);
-        } else {
-            heartbeatCount = new AtomicLong(-1);
         }
     }
 
@@ -239,7 +241,7 @@ public class EurekaRegistryService implements RegistryService {
     }
 
     private void updateHeartbeatCount() {
-        if (heartbeatCount.get() >= 0) {
+        if (trackHeartbeats) {
             heartbeatCount.incrementAndGet();
         }
     }
@@ -261,7 +263,7 @@ public class EurekaRegistryService implements RegistryService {
 
         heartbeatExecutor.set(null);
 
-        if (heartbeatCount.get() >= 0) {
+        if (trackHeartbeats) {
             heartbeatCount.set(0);
         }
     }
@@ -468,7 +470,7 @@ public class EurekaRegistryService implements RegistryService {
 
     void clearRegisteredInstance() {
         registeredInstance.set(null);
-        if (heartbeatCount.get() >= 0) {
+        if (trackHeartbeats) {
             heartbeatCount.set(0);
         }
     }

--- a/src/test/java/org/kiwiproject/registry/eureka/client/EurekaRegistryClientTest.java
+++ b/src/test/java/org/kiwiproject/registry/eureka/client/EurekaRegistryClientTest.java
@@ -1,55 +1,134 @@
 package org.kiwiproject.registry.eureka.client;
 
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static javax.ws.rs.client.Entity.json;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.awaitility.Awaitility.await;
+import static org.kiwiproject.base.KiwiStrings.f;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.List;
+import java.util.Map;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
-import org.kiwiproject.eureka.junit.EurekaServerExtension;
+import org.kiwiproject.jar.KiwiJars;
+import org.kiwiproject.jaxrs.KiwiEntities;
+import org.kiwiproject.jaxrs.KiwiResponses;
+import org.kiwiproject.jaxrs.KiwiStandardResponses;
+// import org.junit.jupiter.api.extension.RegisterExtension;
+// import org.kiwiproject.eureka.junit.EurekaServerExtension;
 import org.kiwiproject.registry.client.RegistryClient;
+import org.kiwiproject.registry.eureka.common.EurekaInstance;
 import org.kiwiproject.registry.eureka.common.EurekaRestClient;
 import org.kiwiproject.registry.eureka.config.EurekaConfig;
+import org.kiwiproject.registry.model.Port;
+import org.kiwiproject.registry.model.ServiceInstance;
+import org.kiwiproject.registry.model.ServicePaths;
+import org.kiwiproject.registry.model.Port.PortType;
+import org.kiwiproject.registry.model.Port.Security;
+import org.kiwiproject.registry.model.ServiceInstance.Status;
 import org.kiwiproject.retry.KiwiRetryerException;
 import org.kiwiproject.retry.RetryException;
 import org.kiwiproject.retry.WaitStrategies;
 import org.kiwiproject.retry.WaitStrategy;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import lombok.extern.slf4j.Slf4j;
 
 import javax.ws.rs.ProcessingException;
 import javax.ws.rs.ServerErrorException;
 import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 @DisplayName("EurekaRegistryClient")
+@Testcontainers
+@Slf4j
 class EurekaRegistryClientTest {
 
-    @RegisterExtension
-    public static final EurekaServerExtension EUREKA = new EurekaServerExtension();
+    // @RegisterExtension
+    // public static final EurekaServerExtension EUREKA = new EurekaServerExtension();
+    
+    @Container
+    public GenericContainer eureka = new GenericContainer(DockerImageName.parse("netflixoss/eureka:1.3.1"))
+        .withExposedPorts(8080)
+        .withLogConsumer(new Slf4jLogConsumer(LOG));
 
     private EurekaRegistryClient client;
     private EurekaConfig config;
 
     @BeforeEach
     void setUp() {
+        var host = eureka.getHost();
+        var port = eureka.getFirstMappedPort();
+
         config = new EurekaConfig();
-        config.setRegistryUrls("http://localhost:" + EUREKA.getPort() + "/eureka/v2");
+
+        var eurekaUrl = f("http://{}:{}/eureka/v2", host, port);
+        config.setRegistryUrls(eurekaUrl);
 
         client = new EurekaRegistryClient(config, new EurekaRestClient());
 
-        EUREKA.registerApplication("TEST-APP", "localhost", "TEST-APP", "UP");
+        var tmpClient = ClientBuilder.newClient();
+        await().atMost(1, MINUTES).until(() -> {
+            var response = tmpClient.target(eurekaUrl).path("apps").request().get();
+            LOG.info("Await status: {}", response.getStatus());
+            return KiwiResponses.successful(response);
+        });
+
+        var serviceInstance = ServiceInstance.builder()
+            .hostName("localhost")
+            .instanceId("TEST-APP")
+            .status(Status.UP)
+            .ports(List.of(Port.builder().number(9999).secure(Security.NOT_SECURE).type(PortType.APPLICATION).build()))
+            .paths(ServicePaths.builder().build())
+            .metadata(Map.of())
+            .commitRef("abcdef")
+            .version("42.0.0")
+            .description("")
+            .build();
+
+        var sampleApp = EurekaInstance.fromServiceInstance(serviceInstance);
+            
+        var loadResponse = tmpClient.target(eurekaUrl)
+            .path("apps/{appId}")
+            .resolveTemplate("appId", "TEST-APP")
+            .request(MediaType.APPLICATION_JSON)
+            .post(json(Map.of("instance", sampleApp)));
+
+        LOG.info("Load response: {} - {}", loadResponse, KiwiEntities.safeReadEntity(loadResponse, "boo"));
+
+        await().atMost(1, MINUTES).until(() -> {
+            var response = tmpClient.target(eurekaUrl)
+                .path("apps/{appId}")
+                .resolveTemplate("appId", "TEST-APP")
+                .request()
+                .get();
+
+            LOG.info("Await load status: {}", response.getStatus());
+            return KiwiResponses.successful(response);
+        });
+            
+        // EUREKA.registerApplication("TEST-APP", "localhost", "TEST-APP", "UP");
     }
 
     @AfterEach
     void cleanupEureka() {
-        EUREKA.clearRegisteredApps();
+        // EUREKA.clearRegisteredApps();
     }
 
     @Nested

--- a/src/test/java/org/kiwiproject/registry/eureka/client/EurekaRegistryClientTest.java
+++ b/src/test/java/org/kiwiproject/registry/eureka/client/EurekaRegistryClientTest.java
@@ -1,24 +1,44 @@
 package org.kiwiproject.registry.eureka.client;
 
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static javax.ws.rs.client.Entity.json;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.kiwiproject.registry.eureka.util.EurekaTestDataHelper.eurekaImage;
+import static org.awaitility.Awaitility.await;
+import static org.kiwiproject.base.KiwiStrings.f;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import lombok.extern.slf4j.Slf4j;
+import java.util.List;
+import java.util.Map;
+
+import javax.ws.rs.ProcessingException;
+import javax.ws.rs.ServerErrorException;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.kiwiproject.jaxrs.KiwiEntities;
+import org.kiwiproject.jaxrs.KiwiResponses;
 import org.kiwiproject.registry.client.RegistryClient;
+import org.kiwiproject.registry.eureka.common.EurekaInstance;
 import org.kiwiproject.registry.eureka.common.EurekaRestClient;
 import org.kiwiproject.registry.eureka.config.EurekaConfig;
-import org.kiwiproject.registry.eureka.util.EurekaTestDataHelper;
+import org.kiwiproject.registry.model.Port;
+import org.kiwiproject.registry.model.Port.PortType;
+import org.kiwiproject.registry.model.Port.Security;
+import org.kiwiproject.registry.model.ServiceInstance;
+import org.kiwiproject.registry.model.ServiceInstance.Status;
+import org.kiwiproject.registry.model.ServicePaths;
 import org.kiwiproject.retry.KiwiRetryerException;
 import org.kiwiproject.retry.RetryException;
 import org.kiwiproject.retry.WaitStrategies;
@@ -27,19 +47,20 @@ import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
 
-import javax.ws.rs.ProcessingException;
-import javax.ws.rs.ServerErrorException;
-import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.core.Response;
+import lombok.extern.slf4j.Slf4j;
 
 @DisplayName("EurekaRegistryClient")
 @Testcontainers
 @Slf4j
 class EurekaRegistryClientTest {
 
+    // @RegisterExtension
+    // public static final EurekaServerExtension EUREKA = new EurekaServerExtension();
+    
     @Container
-    public static GenericContainer eureka = new GenericContainer(eurekaImage())
+    public GenericContainer eureka = new GenericContainer(DockerImageName.parse("netflixoss/eureka:1.3.1"))
         .withExposedPorts(8080)
         .withLogConsumer(new Slf4jLogConsumer(LOG));
 
@@ -48,20 +69,62 @@ class EurekaRegistryClientTest {
 
     @BeforeEach
     void setUp() {
-        var eurekaUrl = EurekaTestDataHelper.eurekaUrl(eureka);
+        var host = eureka.getHost();
+        var port = eureka.getFirstMappedPort();
 
         config = new EurekaConfig();
+
+        var eurekaUrl = f("http://{}:{}/eureka/v2", host, port);
         config.setRegistryUrls(eurekaUrl);
 
         client = new EurekaRegistryClient(config, new EurekaRestClient());
 
-        EurekaTestDataHelper.waitForEurekaToStart(eurekaUrl);
-        EurekaTestDataHelper.loadInstanceAndWaitForRegistration(eurekaUrl);
+        var tmpClient = ClientBuilder.newClient();
+        await().atMost(1, MINUTES).until(() -> {
+            var response = tmpClient.target(eurekaUrl).path("apps").request().get();
+            LOG.info("Await status: {}", response.getStatus());
+            return KiwiResponses.successful(response);
+        });
+
+        var serviceInstance = ServiceInstance.builder()
+            .hostName("localhost")
+            .instanceId("TEST-APP")
+            .status(Status.UP)
+            .ports(List.of(Port.builder().number(9999).secure(Security.NOT_SECURE).type(PortType.APPLICATION).build()))
+            .paths(ServicePaths.builder().build())
+            .metadata(Map.of())
+            .commitRef("abcdef")
+            .version("42.0.0")
+            .description("")
+            .build();
+
+        var sampleApp = EurekaInstance.fromServiceInstance(serviceInstance);
+            
+        var loadResponse = tmpClient.target(eurekaUrl)
+            .path("apps/{appId}")
+            .resolveTemplate("appId", "TEST-APP")
+            .request(MediaType.APPLICATION_JSON)
+            .post(json(Map.of("instance", sampleApp)));
+
+        LOG.info("Load response: {} - {}", loadResponse, KiwiEntities.safeReadEntity(loadResponse, "boo"));
+
+        await().atMost(1, MINUTES).until(() -> {
+            var response = tmpClient.target(eurekaUrl)
+                .path("apps/{appId}")
+                .resolveTemplate("appId", "TEST-APP")
+                .request()
+                .get();
+
+            LOG.info("Await load status: {}", response.getStatus());
+            return KiwiResponses.successful(response);
+        });
+            
+        // EUREKA.registerApplication("TEST-APP", "localhost", "TEST-APP", "UP");
     }
 
     @AfterEach
-    void cleanUp() {
-        EurekaTestDataHelper.clearAllInstances(config.getRegistryUrls());
+    void cleanupEureka() {
+        // EUREKA.clearRegisteredApps();
     }
 
     @Nested

--- a/src/test/java/org/kiwiproject/registry/eureka/client/EurekaRegistryClientTest.java
+++ b/src/test/java/org/kiwiproject/registry/eureka/client/EurekaRegistryClientTest.java
@@ -1,41 +1,24 @@
 package org.kiwiproject.registry.eureka.client;
 
-import static java.util.concurrent.TimeUnit.MINUTES;
-import static javax.ws.rs.client.Entity.json;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.awaitility.Awaitility.await;
-import static org.kiwiproject.base.KiwiStrings.f;
+import static org.kiwiproject.registry.eureka.util.EurekaTestDataHelper.eurekaImage;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.util.List;
-import java.util.Map;
-
+import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.kiwiproject.jar.KiwiJars;
-import org.kiwiproject.jaxrs.KiwiEntities;
-import org.kiwiproject.jaxrs.KiwiResponses;
-import org.kiwiproject.jaxrs.KiwiStandardResponses;
-// import org.junit.jupiter.api.extension.RegisterExtension;
-// import org.kiwiproject.eureka.junit.EurekaServerExtension;
 import org.kiwiproject.registry.client.RegistryClient;
-import org.kiwiproject.registry.eureka.common.EurekaInstance;
 import org.kiwiproject.registry.eureka.common.EurekaRestClient;
 import org.kiwiproject.registry.eureka.config.EurekaConfig;
-import org.kiwiproject.registry.model.Port;
-import org.kiwiproject.registry.model.ServiceInstance;
-import org.kiwiproject.registry.model.ServicePaths;
-import org.kiwiproject.registry.model.Port.PortType;
-import org.kiwiproject.registry.model.Port.Security;
-import org.kiwiproject.registry.model.ServiceInstance.Status;
+import org.kiwiproject.registry.eureka.util.EurekaTestDataHelper;
 import org.kiwiproject.retry.KiwiRetryerException;
 import org.kiwiproject.retry.RetryException;
 import org.kiwiproject.retry.WaitStrategies;
@@ -44,15 +27,10 @@ import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
-import org.testcontainers.utility.DockerImageName;
-
-import lombok.extern.slf4j.Slf4j;
 
 import javax.ws.rs.ProcessingException;
 import javax.ws.rs.ServerErrorException;
 import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.client.ClientBuilder;
-import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 @DisplayName("EurekaRegistryClient")
@@ -60,11 +38,8 @@ import javax.ws.rs.core.Response;
 @Slf4j
 class EurekaRegistryClientTest {
 
-    // @RegisterExtension
-    // public static final EurekaServerExtension EUREKA = new EurekaServerExtension();
-    
     @Container
-    public GenericContainer eureka = new GenericContainer(DockerImageName.parse("netflixoss/eureka:1.3.1"))
+    public static GenericContainer eureka = new GenericContainer(eurekaImage())
         .withExposedPorts(8080)
         .withLogConsumer(new Slf4jLogConsumer(LOG));
 
@@ -73,62 +48,20 @@ class EurekaRegistryClientTest {
 
     @BeforeEach
     void setUp() {
-        var host = eureka.getHost();
-        var port = eureka.getFirstMappedPort();
+        var eurekaUrl = EurekaTestDataHelper.eurekaUrl(eureka);
 
         config = new EurekaConfig();
-
-        var eurekaUrl = f("http://{}:{}/eureka/v2", host, port);
         config.setRegistryUrls(eurekaUrl);
 
         client = new EurekaRegistryClient(config, new EurekaRestClient());
 
-        var tmpClient = ClientBuilder.newClient();
-        await().atMost(1, MINUTES).until(() -> {
-            var response = tmpClient.target(eurekaUrl).path("apps").request().get();
-            LOG.info("Await status: {}", response.getStatus());
-            return KiwiResponses.successful(response);
-        });
-
-        var serviceInstance = ServiceInstance.builder()
-            .hostName("localhost")
-            .instanceId("TEST-APP")
-            .status(Status.UP)
-            .ports(List.of(Port.builder().number(9999).secure(Security.NOT_SECURE).type(PortType.APPLICATION).build()))
-            .paths(ServicePaths.builder().build())
-            .metadata(Map.of())
-            .commitRef("abcdef")
-            .version("42.0.0")
-            .description("")
-            .build();
-
-        var sampleApp = EurekaInstance.fromServiceInstance(serviceInstance);
-            
-        var loadResponse = tmpClient.target(eurekaUrl)
-            .path("apps/{appId}")
-            .resolveTemplate("appId", "TEST-APP")
-            .request(MediaType.APPLICATION_JSON)
-            .post(json(Map.of("instance", sampleApp)));
-
-        LOG.info("Load response: {} - {}", loadResponse, KiwiEntities.safeReadEntity(loadResponse, "boo"));
-
-        await().atMost(1, MINUTES).until(() -> {
-            var response = tmpClient.target(eurekaUrl)
-                .path("apps/{appId}")
-                .resolveTemplate("appId", "TEST-APP")
-                .request()
-                .get();
-
-            LOG.info("Await load status: {}", response.getStatus());
-            return KiwiResponses.successful(response);
-        });
-            
-        // EUREKA.registerApplication("TEST-APP", "localhost", "TEST-APP", "UP");
+        EurekaTestDataHelper.waitForEurekaToStart(eurekaUrl);
+        EurekaTestDataHelper.loadInstanceAndWaitForRegistration(eurekaUrl);
     }
 
     @AfterEach
-    void cleanupEureka() {
-        // EUREKA.clearRegisteredApps();
+    void cleanUp() {
+        EurekaTestDataHelper.clearAllInstances(config.getRegistryUrls());
     }
 
     @Nested

--- a/src/test/java/org/kiwiproject/registry/eureka/common/EurekaRestClientTest.java
+++ b/src/test/java/org/kiwiproject/registry/eureka/common/EurekaRestClientTest.java
@@ -14,7 +14,6 @@ import static org.kiwiproject.test.jaxrs.JaxrsTestHelper.assertNoContentResponse
 import static org.kiwiproject.test.jaxrs.JaxrsTestHelper.assertNotFoundResponse;
 import static org.kiwiproject.test.jaxrs.JaxrsTestHelper.assertOkResponse;
 
-import com.netflix.appinfo.InstanceInfo;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -49,6 +48,8 @@ class EurekaRestClientTest {
     void setUp() {
         client = new EurekaRestClient();
         eurekaBaseUrl = EurekaTestDataHelper.eurekaUrl(eureka);
+
+        EurekaTestDataHelper.waitForEurekaToStart(eurekaBaseUrl);
     }
 
     @AfterEach
@@ -130,7 +131,7 @@ class EurekaRestClientTest {
             var instanceResponse = client.findInstance(eurekaBaseUrl, "APPID", "INSTANCEID");
             var eurekaResponse = instanceResponse.readEntity(KiwiGenericTypes.MAP_OF_STRING_TO_OBJECT_GENERIC_TYPE);
             var instance = EurekaResponseParser.parseEurekaInstanceResponse(eurekaResponse);
-            assertThat(instance.getStatus()).isEqualTo(InstanceInfo.InstanceStatus.UP.name());
+            assertThat(instance.getStatus()).isEqualTo("UP");
         }
 
     }

--- a/src/test/java/org/kiwiproject/registry/eureka/server/EurekaHeartbeatSenderTest.java
+++ b/src/test/java/org/kiwiproject/registry/eureka/server/EurekaHeartbeatSenderTest.java
@@ -2,6 +2,7 @@ package org.kiwiproject.registry.eureka.server;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.kiwiproject.jaxrs.KiwiStandardResponses.standardGetResponse;
 import static org.kiwiproject.registry.eureka.server.EurekaHeartbeatSender.FailureHandlerResult.CANNOT_SELF_HEAL;
 import static org.kiwiproject.registry.eureka.server.EurekaHeartbeatSender.FailureHandlerResult.SELF_HEALING_FAILED;
 import static org.kiwiproject.registry.eureka.server.EurekaHeartbeatSender.FailureHandlerResult.SELF_HEALING_SUCCEEDED;
@@ -26,6 +27,9 @@ import org.mockito.ArgumentCaptor;
 
 import java.net.ConnectException;
 import java.net.SocketTimeoutException;
+import java.time.Instant;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 import javax.ws.rs.ProcessingException;
 import javax.ws.rs.core.Response;
 
@@ -36,6 +40,8 @@ class EurekaHeartbeatSenderTest {
     private EurekaHeartbeatSender sender;
     private EurekaRestClient client;
 
+    private AtomicInteger heartbeatCount;
+
     @BeforeEach
     void setUp() {
         service = mock(EurekaRegistryService.class);
@@ -44,7 +50,9 @@ class EurekaHeartbeatSenderTest {
         var serviceInstance = ServiceInstance.fromServiceInfo(ServiceInfoHelper.buildTestServiceInfo())
                 .withStatus(ServiceInstance.Status.UP);
         var eurekaInstance = EurekaInstance.fromServiceInstance(serviceInstance).withApp("test-service-app");
-        sender = new EurekaHeartbeatSender(client, service, eurekaInstance, new EurekaUrlProvider("http://localhost:8764"), () -> {});
+
+        heartbeatCount = new AtomicInteger(0);
+        sender = new EurekaHeartbeatSender(client, service, eurekaInstance, new EurekaUrlProvider("http://localhost:8764"), () -> heartbeatCount.incrementAndGet());
     }
 
     @Nested
@@ -105,6 +113,7 @@ class EurekaHeartbeatSenderTest {
 
             assertThat(sender.getHeartbeatFailures()).isEqualTo(1);
             assertThat(sender.getHeartbeatFailureStartedAt()).isNotNull();
+            assertThat(heartbeatCount).hasValue(0);
         }
 
         @Test
@@ -116,6 +125,22 @@ class EurekaHeartbeatSenderTest {
 
             assertThat(sender.getHeartbeatFailures()).isEqualTo(2);
             assertThat(sender.getHeartbeatFailureStartedAt()).isNotNull();
+            assertThat(heartbeatCount).hasValue(0);
+        }
+
+        @Test
+        void whenSendCallSucceedsResetFailuresAndCallListener() {
+            when(client.sendHeartbeat(anyString(), anyString(), anyString())).thenReturn(standardGetResponse(List.of(), "foo"));
+
+            // Setting previous failures to one, so we can see it change
+            sender.setHeartbeatFailures(1);
+            sender.setHeartbeatFailureStartedAt(Instant.now().minusSeconds(30));
+
+            sender.run();
+
+            assertThat(sender.getHeartbeatFailures()).isZero();
+            assertThat(sender.getHeartbeatFailureStartedAt()).isNull();
+            assertThat(heartbeatCount).hasValue(1);
         }
     }
 

--- a/src/test/java/org/kiwiproject/registry/eureka/server/EurekaHeartbeatSenderTest.java
+++ b/src/test/java/org/kiwiproject/registry/eureka/server/EurekaHeartbeatSenderTest.java
@@ -24,10 +24,10 @@ import org.kiwiproject.registry.model.ServiceInstance;
 import org.kiwiproject.registry.util.ServiceInfoHelper;
 import org.mockito.ArgumentCaptor;
 
-import javax.ws.rs.ProcessingException;
-import javax.ws.rs.core.Response;
 import java.net.ConnectException;
 import java.net.SocketTimeoutException;
+import javax.ws.rs.ProcessingException;
+import javax.ws.rs.core.Response;
 
 @DisplayName("EurekaHeartbeatSender")
 class EurekaHeartbeatSenderTest {

--- a/src/test/java/org/kiwiproject/registry/eureka/server/EurekaHeartbeatSenderTest.java
+++ b/src/test/java/org/kiwiproject/registry/eureka/server/EurekaHeartbeatSenderTest.java
@@ -44,7 +44,7 @@ class EurekaHeartbeatSenderTest {
         var serviceInstance = ServiceInstance.fromServiceInfo(ServiceInfoHelper.buildTestServiceInfo())
                 .withStatus(ServiceInstance.Status.UP);
         var eurekaInstance = EurekaInstance.fromServiceInstance(serviceInstance).withApp("test-service-app");
-        sender = new EurekaHeartbeatSender(client, service, eurekaInstance, new EurekaUrlProvider("http://localhost:8764"));
+        sender = new EurekaHeartbeatSender(client, service, eurekaInstance, new EurekaUrlProvider("http://localhost:8764"), () -> {});
     }
 
     @Nested

--- a/src/test/java/org/kiwiproject/registry/eureka/server/EurekaRegistryServiceIntegrationTest.java
+++ b/src/test/java/org/kiwiproject/registry/eureka/server/EurekaRegistryServiceIntegrationTest.java
@@ -67,7 +67,7 @@ class EurekaRegistryServiceIntegrationTest {
         config = new EurekaRegistrationConfig();
         config.setHeartbeatIntervalInSeconds(1);
         config.setRegistryUrls(EurekaTestDataHelper.eurekaUrl(eureka));
-        config.setShouldTrackHeartbeats(true);
+        config.setTrackHeartbeats(true);
 
         service = new EurekaRegistryService(config, client, environment);
 

--- a/src/test/java/org/kiwiproject/registry/eureka/server/EurekaRegistryServiceIntegrationTest.java
+++ b/src/test/java/org/kiwiproject/registry/eureka/server/EurekaRegistryServiceIntegrationTest.java
@@ -6,6 +6,11 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.awaitility.Awaitility.await;
 import static org.kiwiproject.jaxrs.KiwiStandardResponses.standardBadRequestResponse;
 import static org.kiwiproject.registry.eureka.server.EurekaRegistryService.APP_TIMESTAMP_FORMATTER;
+import static org.kiwiproject.registry.eureka.util.EurekaTestDataHelper.assertApplicationIsNotRegistered;
+import static org.kiwiproject.registry.eureka.util.EurekaTestDataHelper.assertApplicationIsRegistered;
+import static org.kiwiproject.registry.eureka.util.EurekaTestDataHelper.clearAllInstances;
+import static org.kiwiproject.registry.eureka.util.EurekaTestDataHelper.eurekaImage;
+import static org.kiwiproject.registry.eureka.util.EurekaTestDataHelper.loadInstanceAndWaitForRegistration;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doReturn;
@@ -13,7 +18,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
-import com.netflix.appinfo.InstanceInfo;
+import lombok.extern.slf4j.Slf4j;
 import org.assertj.core.api.SoftAssertions;
 import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
 import org.junit.jupiter.api.AfterEach;
@@ -22,15 +27,18 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.api.extension.RegisterExtension;
 import org.kiwiproject.base.KiwiEnvironment;
-import org.kiwiproject.eureka.junit.EurekaServerExtension;
 import org.kiwiproject.registry.eureka.common.EurekaInstance;
 import org.kiwiproject.registry.eureka.common.EurekaRestClient;
 import org.kiwiproject.registry.eureka.config.EurekaRegistrationConfig;
+import org.kiwiproject.registry.eureka.util.EurekaTestDataHelper;
 import org.kiwiproject.registry.exception.RegistrationException;
 import org.kiwiproject.registry.model.ServiceInstance;
 import org.kiwiproject.registry.util.ServiceInfoHelper;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.time.Instant;
 import java.util.Locale;
@@ -38,10 +46,14 @@ import java.util.concurrent.TimeUnit;
 
 @DisplayName("EurekaRegistryService")
 @ExtendWith(SoftAssertionsExtension.class)
+@Testcontainers
+@Slf4j
 class EurekaRegistryServiceIntegrationTest {
 
-    @RegisterExtension
-    public static final EurekaServerExtension EUREKA = new EurekaServerExtension();
+    @Container
+    public static GenericContainer eureka = new GenericContainer(eurekaImage())
+            .withExposedPorts(8080)
+            .withLogConsumer(new Slf4jLogConsumer(LOG));
 
     private KiwiEnvironment environment;
     private EurekaRegistryService service;
@@ -55,14 +67,14 @@ class EurekaRegistryServiceIntegrationTest {
 
         config = new EurekaRegistrationConfig();
         config.setHeartbeatIntervalInSeconds(1);
-        config.setRegistryUrls("http://localhost:" + EUREKA.getPort() + "/eureka/v2");
+        config.setRegistryUrls(EurekaTestDataHelper.eurekaUrl(eureka));
 
         service = new EurekaRegistryService(config, client, environment);
     }
 
     @AfterEach
     void cleanupEureka() {
-        EUREKA.clearRegisteredApps();
+        EurekaTestDataHelper.clearAllInstances(config.getRegistryUrls());
 
         if (nonNull(service.heartbeatExecutor.get())) {
             service.heartbeatExecutor.get().shutdownNow();
@@ -125,11 +137,9 @@ class EurekaRegistryServiceIntegrationTest {
 
             assertThat(eurekaInstance.getApp()).isEqualTo(expectedAppId);
             assertThat(service.heartbeatExecutor.get()).isNotNull();
-            assertThat(EUREKA.getRegisteredApplications()).extracting("name").contains(expectedAppId);
+            assertApplicationIsRegistered(expectedAppId, config.getRegistryUrls());
 
-            await().atMost(5, TimeUnit.SECONDS).until(() -> EUREKA.getHeartbeatCount() > 1);
-
-            assertThat(EUREKA.getHeartbeatCount()).isGreaterThan(1);
+            verifyHeartbeats(5, 1);
         }
 
         @Test
@@ -149,7 +159,7 @@ class EurekaRegistryServiceIntegrationTest {
             assertThat(service.registeredInstance.get()).isNull();
 
             var appId = serviceInstance.getServiceName().toUpperCase(Locale.getDefault()) + "-" + APP_TIMESTAMP_FORMATTER.format(now);
-            assertThat(EUREKA.isApplicationRegistered(appId)).isFalse();
+            assertApplicationIsNotRegistered(appId, config.getRegistryUrls());
         }
 
         @Test
@@ -173,7 +183,7 @@ class EurekaRegistryServiceIntegrationTest {
                     .hasMessage("Unable to obtain app " + appId + ", instance " + serviceInstance.getHostName() + " from Eureka during registration after 10 attempts");
 
             assertThat(service.registeredInstance.get()).isNull();
-            assertThat(EUREKA.isApplicationRegistered(appId)).isTrue();
+            assertApplicationIsRegistered(appId, config.getRegistryUrls());
         }
 
         @Test
@@ -200,11 +210,7 @@ class EurekaRegistryServiceIntegrationTest {
             var expectedAppId = serviceInstance.getServiceName().toUpperCase(Locale.getDefault())
                     + "-" + APP_TIMESTAMP_FORMATTER.format(now);
 
-            assertThat(EUREKA.getRegisteredApplications()).extracting("name").contains(expectedAppId);
-
-            await().atMost(5, TimeUnit.SECONDS).until(() -> EUREKA.getHeartbeatCount() > 1);
-
-            assertThat(EUREKA.getHeartbeatCount()).isGreaterThan(1);
+            assertApplicationIsRegistered(expectedAppId, config.getRegistryUrls());
         }
 
         @Test
@@ -223,19 +229,25 @@ class EurekaRegistryServiceIntegrationTest {
             var expectedAppId = serviceInstance.getServiceName().toUpperCase(Locale.getDefault())
                     + "-" + APP_TIMESTAMP_FORMATTER.format(now);
 
-            assertThat(EUREKA.getRegisteredApplications()).extracting("name").contains(expectedAppId);
+            assertApplicationIsRegistered(expectedAppId, config.getRegistryUrls());
 
-            await().atMost(10, TimeUnit.SECONDS).until(() -> EUREKA.getHeartbeatCount() > 1);
+            verifyHeartbeats(10, 1);
 
-            EUREKA.clearRegisteredApps();
+            clearAllInstances(config.getRegistryUrls());
 
-            await().atMost(10, TimeUnit.SECONDS).until(() -> EUREKA.getHeartbeatCount() > 3);
-
-            assertThat(EUREKA.getHeartbeatCount()).isEqualTo(4);
+            verifyHeartbeats(10, 3);
 
             assertThat(eurekaInstance).isNotSameAs(service.registeredInstance.get());
             assertThat(heartbeatExecutor).isNotSameAs(service.heartbeatExecutor.get());
         }
+    }
+
+    private void verifyHeartbeats(int maxWaitTimeInSeconds, int expectedCount) {
+        await().atMost(maxWaitTimeInSeconds, TimeUnit.SECONDS).until(() -> {
+            LOG.info("Heartbeat count: {}", service.heartbeatCount.get());
+            return service.heartbeatCount.get() > expectedCount;
+        });
+        assertThat(service.heartbeatCount.get()).isGreaterThan(expectedCount);
     }
 
     @Nested
@@ -247,18 +259,16 @@ class EurekaRegistryServiceIntegrationTest {
             var initialEurekaInstance = EurekaInstance.fromServiceInstance(serviceInstance).withApp("APPID").withStatus("STARTING");
             service.registeredInstance.set(initialEurekaInstance);
 
-            EUREKA.registerApplication(initialEurekaInstance.getApp(), initialEurekaInstance.getInstanceId(), "VIP-SERVICE", "STARTING");
+            var sampleInstance = EurekaTestDataHelper.sampleInstance(initialEurekaInstance.getApp(), initialEurekaInstance.getInstanceId(),
+                    initialEurekaInstance.getVipAddress(), ServiceInstance.Status.STARTING);
+
+            loadInstanceAndWaitForRegistration(sampleInstance, config.getRegistryUrls());
 
             service.updateStatus(ServiceInstance.Status.UP);
 
             var updatedEurekaInstance = service.registeredInstance.get();
             assertThat(updatedEurekaInstance).isNotSameAs(initialEurekaInstance);
             assertThat(updatedEurekaInstance.getStatus()).isEqualTo(ServiceInstance.Status.UP.name());
-
-            assertThat(EUREKA.isApplicationRegistered("APPID")).isTrue();
-
-            var instances = EUREKA.getRegisteredApplication("APPID").getInstances();
-            assertThat(instances).extracting("status").contains(InstanceInfo.InstanceStatus.UP);
         }
 
         @Test
@@ -293,12 +303,13 @@ class EurekaRegistryServiceIntegrationTest {
         void shouldUnRegister() {
             service.registeredInstance.set(EurekaInstance.builder().app("APPID").hostName("INSTANCEID").build());
 
-            EUREKA.registerApplication("APPID", "INSTANCEID", "VIP-SERVICE", "UP");
+            var sampleInstance = EurekaTestDataHelper.sampleInstance("APPID", "INSTANCEID", "VIP-SERVICE", ServiceInstance.Status.UP);
+            loadInstanceAndWaitForRegistration(sampleInstance, config.getRegistryUrls());
 
             service.unregister();
 
             assertThat(service.registeredInstance.get()).isNull();
-            assertThat(EUREKA.isApplicationRegistered("APPID")).isFalse();
+            assertApplicationIsNotRegistered("APPID", config.getRegistryUrls());
         }
 
         @Test

--- a/src/test/java/org/kiwiproject/registry/eureka/server/EurekaRegistryServiceIntegrationTest.java
+++ b/src/test/java/org/kiwiproject/registry/eureka/server/EurekaRegistryServiceIntegrationTest.java
@@ -17,10 +17,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
-import java.time.Instant;
-import java.util.Locale;
-import java.util.concurrent.TimeUnit;
-
+import lombok.extern.slf4j.Slf4j;
 import org.assertj.core.api.SoftAssertions;
 import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
 import org.junit.jupiter.api.AfterEach;
@@ -42,7 +39,9 @@ import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
-import lombok.extern.slf4j.Slf4j;
+import java.time.Instant;
+import java.util.Locale;
+import java.util.concurrent.TimeUnit;
 
 @DisplayName("EurekaRegistryService")
 @ExtendWith(SoftAssertionsExtension.class)
@@ -71,6 +70,8 @@ class EurekaRegistryServiceIntegrationTest {
         config.setShouldTrackHeartbeats(true);
 
         service = new EurekaRegistryService(config, client, environment);
+
+        EurekaTestDataHelper.waitForEurekaToStart(config.getRegistryUrls());
     }
 
     @AfterEach

--- a/src/test/java/org/kiwiproject/registry/eureka/server/EurekaRegistryServiceTest.java
+++ b/src/test/java/org/kiwiproject/registry/eureka/server/EurekaRegistryServiceTest.java
@@ -1,0 +1,151 @@
+package org.kiwiproject.registry.eureka.server;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.kiwiproject.base.KiwiStrings.f;
+import static org.kiwiproject.registry.eureka.server.EurekaRegistryService.APP_TIMESTAMP_FORMATTER;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.kiwiproject.base.KiwiEnvironment;
+import org.kiwiproject.registry.eureka.common.EurekaInstance;
+import org.kiwiproject.registry.eureka.common.EurekaRestClient;
+import org.kiwiproject.registry.eureka.config.EurekaRegistrationConfig;
+import org.kiwiproject.registry.exception.RegistrationException;
+import org.kiwiproject.registry.model.Port;
+import org.kiwiproject.registry.model.ServiceInstance;
+import org.kiwiproject.registry.model.ServicePaths;
+import org.kiwiproject.retry.SimpleRetryer;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Locale;
+import java.util.concurrent.TimeUnit;
+import javax.ws.rs.core.Response;
+
+/**
+ * Unlike the {@link EurekaRegistryServiceIntegrationTest}, this set of tests will mock out the actual calls to Eureka
+ * so that we can test edge cases and error handling.
+ */
+@DisplayName("EurekaRegistryService")
+class EurekaRegistryServiceTest {
+
+    private EurekaRestClient eurekaRestClient;
+    private KiwiEnvironment kiwiEnvironment;
+    private EurekaRegistrationConfig config;
+
+    private EurekaRegistryService eurekaRegistryService;
+
+    @BeforeEach
+    void setUp() {
+        eurekaRestClient = mock(EurekaRestClient.class);
+        kiwiEnvironment = mock(KiwiEnvironment.class);
+        config = new EurekaRegistrationConfig();
+        config.setRegistryUrls("https://localhost:8761/eureka/v2");
+
+        var retryer = SimpleRetryer.builder()
+                .environment(kiwiEnvironment)
+                .maxAttempts(5)
+                .retryDelayTime(200)
+                .retryDelayUnit(TimeUnit.MILLISECONDS)
+                .build();
+
+        eurekaRegistryService = new EurekaRegistryService(config, eurekaRestClient, kiwiEnvironment, retryer, retryer, retryer, retryer);
+    }
+
+    @Nested
+    class Register {
+        @Test
+        void shouldThrowIllegalStateWhenAlreadyRegistered() {
+            eurekaRegistryService.registeredInstance.set(EurekaInstance.builder().build());
+
+            var instance = ServiceInstance.builder().build();
+            assertThatThrownBy(() -> eurekaRegistryService.register(instance))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageStartingWith("Cannot register. Already managing a registered instance: ");
+        }
+
+        @Test
+        void shouldThrowRegistrationExceptionWhenRetriesRunOutDueToNonSuccessResponse() {
+            var now = Instant.now();
+            when(kiwiEnvironment.currentInstant()).thenReturn(now);
+
+            var appId = f("test-service-{}", APP_TIMESTAMP_FORMATTER.format(now)).toUpperCase(Locale.getDefault());
+            when(eurekaRestClient.register(eq(config.getRegistryUrls()), eq(appId), any(EurekaInstance.class)))
+                    .thenReturn(Response.serverError().build());
+
+            var instance = ServiceInstance.builder()
+                    .serviceName("test-service")
+                    .status(ServiceInstance.Status.UP)
+                    .ports(List.of(Port.of(8080, Port.PortType.APPLICATION, Port.Security.SECURE)))
+                    .paths(ServicePaths.builder().build())
+                    .description("The best service")
+                    .version("42.0.1")
+                    .commitRef("abcdef")
+                    .build();
+
+            assertThatThrownBy(() -> eurekaRegistryService.register(instance))
+                    .isInstanceOf(RegistrationException.class)
+                    .hasMessageContaining("Received errors or non-204 responses on ALL")
+                    .hasMessageContaining("attempts to register (via POST) with Eureka");
+        }
+
+        @Test
+        void shouldThrowRegistrationExceptionWhenRetriesRunOutDueToException() {
+            var now = Instant.now();
+            when(kiwiEnvironment.currentInstant()).thenReturn(now);
+
+            var appId = f("test-service-{}", APP_TIMESTAMP_FORMATTER.format(now)).toUpperCase(Locale.getDefault());
+            when(eurekaRestClient.register(eq(config.getRegistryUrls()), eq(appId), any(EurekaInstance.class)))
+                    .thenThrow(new RuntimeException("oops"));
+
+            var instance = ServiceInstance.builder()
+                    .serviceName("test-service")
+                    .status(ServiceInstance.Status.UP)
+                    .ports(List.of(Port.of(8080, Port.PortType.APPLICATION, Port.Security.SECURE)))
+                    .paths(ServicePaths.builder().build())
+                    .description("The best service")
+                    .version("42.0.1")
+                    .commitRef("abcdef")
+                    .build();
+
+            assertThatThrownBy(() -> eurekaRegistryService.register(instance))
+                    .isInstanceOf(RegistrationException.class)
+                    .hasMessageContaining("Received errors or non-204 responses on ALL")
+                    .hasMessageContaining("attempts to register (via POST) with Eureka");
+        }
+
+        @Test
+        void shouldThrowRegistrationExceptionWhenRetriesRunOutWaitingForRegistrationDueToNonSuccessResponse() {
+            var now = Instant.now();
+            when(kiwiEnvironment.currentInstant()).thenReturn(now);
+
+            var appId = f("test-service-{}", APP_TIMESTAMP_FORMATTER.format(now)).toUpperCase(Locale.getDefault());
+            when(eurekaRestClient.register(eq(config.getRegistryUrls()), eq(appId), any(EurekaInstance.class)))
+                    .thenReturn(Response.noContent().build());
+
+            when(eurekaRestClient.findInstance(config.getRegistryUrls(), appId, "localhost"))
+                    .thenReturn(Response.serverError().build());
+
+            var instance = ServiceInstance.builder()
+                    .serviceName("test-service")
+                    .status(ServiceInstance.Status.UP)
+                    .ports(List.of(Port.of(8080, Port.PortType.APPLICATION, Port.Security.SECURE)))
+                    .paths(ServicePaths.builder().build())
+                    .description("The best service")
+                    .version("42.0.1")
+                    .commitRef("abcdef")
+                    .build();
+
+            assertThatThrownBy(() -> eurekaRegistryService.register(instance))
+                    .isInstanceOf(RegistrationException.class)
+                    .hasMessageContaining("Received errors or non-204 responses on ALL")
+                    .hasMessageContaining("attempts to register (via POST) with Eureka");
+        }
+    }
+}

--- a/src/test/java/org/kiwiproject/registry/eureka/server/EurekaRegistryServiceTest.java
+++ b/src/test/java/org/kiwiproject/registry/eureka/server/EurekaRegistryServiceTest.java
@@ -1,8 +1,11 @@
 package org.kiwiproject.registry.eureka.server;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.awaitility.Awaitility.await;
 import static org.kiwiproject.base.KiwiStrings.f;
 import static org.kiwiproject.registry.eureka.server.EurekaRegistryService.APP_TIMESTAMP_FORMATTER;
+import static org.kiwiproject.test.constants.KiwiTestConstants.JSON_HELPER;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -20,11 +23,15 @@ import org.kiwiproject.registry.exception.RegistrationException;
 import org.kiwiproject.registry.model.Port;
 import org.kiwiproject.registry.model.ServiceInstance;
 import org.kiwiproject.registry.model.ServicePaths;
+import org.kiwiproject.registry.util.ResponseMock;
 import org.kiwiproject.retry.SimpleRetryer;
+
+import lombok.extern.slf4j.Slf4j;
 
 import java.time.Instant;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import javax.ws.rs.core.Response;
 
@@ -33,11 +40,13 @@ import javax.ws.rs.core.Response;
  * so that we can test edge cases and error handling.
  */
 @DisplayName("EurekaRegistryService")
+@Slf4j
 class EurekaRegistryServiceTest {
 
     private EurekaRestClient eurekaRestClient;
     private KiwiEnvironment kiwiEnvironment;
     private EurekaRegistrationConfig config;
+    private SimpleRetryer retryer;
 
     private EurekaRegistryService eurekaRegistryService;
 
@@ -48,7 +57,7 @@ class EurekaRegistryServiceTest {
         config = new EurekaRegistrationConfig();
         config.setRegistryUrls("https://localhost:8761/eureka/v2");
 
-        var retryer = SimpleRetryer.builder()
+        retryer = SimpleRetryer.builder()
                 .environment(kiwiEnvironment)
                 .maxAttempts(5)
                 .retryDelayTime(200)
@@ -75,9 +84,10 @@ class EurekaRegistryServiceTest {
             var now = Instant.now();
             when(kiwiEnvironment.currentInstant()).thenReturn(now);
 
+            var serverErrorResponse = ResponseMock.simulateInbound(Response.serverError().build());
             var appId = f("test-service-{}", APP_TIMESTAMP_FORMATTER.format(now)).toUpperCase(Locale.getDefault());
             when(eurekaRestClient.register(eq(config.getRegistryUrls()), eq(appId), any(EurekaInstance.class)))
-                    .thenReturn(Response.serverError().build());
+                    .thenReturn(serverErrorResponse);
 
             var instance = ServiceInstance.builder()
                     .serviceName("test-service")
@@ -125,15 +135,18 @@ class EurekaRegistryServiceTest {
             var now = Instant.now();
             when(kiwiEnvironment.currentInstant()).thenReturn(now);
 
+            var noContentResponse = ResponseMock.simulateInbound(Response.noContent().build());
             var appId = f("test-service-{}", APP_TIMESTAMP_FORMATTER.format(now)).toUpperCase(Locale.getDefault());
             when(eurekaRestClient.register(eq(config.getRegistryUrls()), eq(appId), any(EurekaInstance.class)))
-                    .thenReturn(Response.noContent().build());
+                    .thenReturn(noContentResponse);
 
+            var serverErrorResponse = ResponseMock.simulateInbound(Response.serverError().build());        
             when(eurekaRestClient.findInstance(config.getRegistryUrls(), appId, "localhost"))
-                    .thenReturn(Response.serverError().build());
+                    .thenReturn(serverErrorResponse);
 
             var instance = ServiceInstance.builder()
                     .serviceName("test-service")
+                    .hostName("localhost")
                     .status(ServiceInstance.Status.UP)
                     .ports(List.of(Port.of(8080, Port.PortType.APPLICATION, Port.Security.SECURE)))
                     .paths(ServicePaths.builder().build())
@@ -144,8 +157,159 @@ class EurekaRegistryServiceTest {
 
             assertThatThrownBy(() -> eurekaRegistryService.register(instance))
                     .isInstanceOf(RegistrationException.class)
-                    .hasMessageContaining("Received errors or non-204 responses on ALL")
-                    .hasMessageContaining("attempts to register (via POST) with Eureka");
+                    .hasMessageContaining("Unable to obtain app " + appId + ", instance localhost from Eureka during registration after");
         }
+
+        @Test
+        void shouldThrowRegistrationExceptionWhenRetriesRunOutWaitingForRegistrationDueToException() {
+            var now = Instant.now();
+            when(kiwiEnvironment.currentInstant()).thenReturn(now);
+
+            var noContentResponse = ResponseMock.simulateInbound(Response.noContent().build());
+            var appId = f("test-service-{}", APP_TIMESTAMP_FORMATTER.format(now)).toUpperCase(Locale.getDefault());
+            when(eurekaRestClient.register(eq(config.getRegistryUrls()), eq(appId), any(EurekaInstance.class)))
+                    .thenReturn(noContentResponse);
+
+            when(eurekaRestClient.findInstance(config.getRegistryUrls(), appId, "localhost"))
+                    .thenThrow(new RuntimeException("oops"));
+
+            var instance = ServiceInstance.builder()
+                    .serviceName("test-service")
+                    .hostName("localhost")
+                    .status(ServiceInstance.Status.UP)
+                    .ports(List.of(Port.of(8080, Port.PortType.APPLICATION, Port.Security.SECURE)))
+                    .paths(ServicePaths.builder().build())
+                    .description("The best service")
+                    .version("42.0.1")
+                    .commitRef("abcdef")
+                    .build();
+
+            assertThatThrownBy(() -> eurekaRegistryService.register(instance))
+                    .isInstanceOf(RegistrationException.class)
+                    .hasMessageContaining("Unable to obtain app " + appId + ", instance localhost from Eureka during registration after");
+        }
+
+        @Test
+        void shouldRegisterInstanceAndReturnServiceInstanceWithoutNativeData() {
+            var now = Instant.now();
+            when(kiwiEnvironment.currentInstant()).thenReturn(now);
+
+            var noContentResponse = ResponseMock.simulateInbound(Response.noContent().build());
+            var appId = f("test-service-{}", APP_TIMESTAMP_FORMATTER.format(now)).toUpperCase(Locale.getDefault());
+            when(eurekaRestClient.register(eq(config.getRegistryUrls()), eq(appId), any(EurekaInstance.class)))
+                .thenReturn(noContentResponse);
+
+            var instance = ServiceInstance.builder()
+                .serviceName("test-service")
+                .hostName("localhost")
+                .status(ServiceInstance.Status.UP)
+                .ports(List.of(Port.of(8080, Port.PortType.APPLICATION, Port.Security.SECURE)))
+                .paths(ServicePaths.builder().build())
+                .description("The best service")
+                .version("42.0.1")
+                .commitRef("abcdef")
+                .build();   
+
+            var eurekaInstance = JSON_HELPER.convertToMap(EurekaInstance.fromServiceInstance(instance));
+            var okResponse = ResponseMock.simulateInbound(Response.ok(Map.of("instance", eurekaInstance)).build());    
+            when(eurekaRestClient.findInstance(config.getRegistryUrls(), appId, "localhost"))
+                .thenReturn(okResponse);
+
+             var registeredInstance = eurekaRegistryService.register(instance);
+
+             assertThat(registeredInstance).isNotNull();
+             assertThat(registeredInstance.getNativeRegistryData()).isNullOrEmpty();
+        }
+
+        @Test
+        void shouldRegisterInstanceAndReturnServiceInstanceWithNativeData() {
+            config.setIncludeNativeData(true);
+
+            var now = Instant.now();
+            when(kiwiEnvironment.currentInstant()).thenReturn(now);
+
+            var noContentResponse = ResponseMock.simulateInbound(Response.noContent().build());
+            var appId = f("test-service-{}", APP_TIMESTAMP_FORMATTER.format(now)).toUpperCase(Locale.getDefault());
+            when(eurekaRestClient.register(eq(config.getRegistryUrls()), eq(appId), any(EurekaInstance.class)))
+                .thenReturn(noContentResponse);
+
+            var instance = ServiceInstance.builder()
+                .serviceName("test-service")
+                .hostName("localhost")
+                .status(ServiceInstance.Status.UP)
+                .ports(List.of(Port.of(8080, Port.PortType.APPLICATION, Port.Security.SECURE)))
+                .paths(ServicePaths.builder().build())
+                .description("The best service")
+                .version("42.0.1")
+                .commitRef("abcdef")
+                .build();   
+
+            var eurekaInstance = JSON_HELPER.convertToMap(EurekaInstance.fromServiceInstance(instance));
+            var okResponse = ResponseMock.simulateInbound(Response.ok(Map.of("instance", eurekaInstance)).build());    
+            when(eurekaRestClient.findInstance(config.getRegistryUrls(), appId, "localhost"))
+                .thenReturn(okResponse);
+
+             var registeredInstance = eurekaRegistryService.register(instance);
+
+             assertThat(registeredInstance).isNotNull();
+             assertThat(registeredInstance.getNativeRegistryData()).isNotEmpty();
+        }
+
+        @Nested
+        class WithHeartbeats {
+            @BeforeEach
+            void setUp() {
+                config.setTrackHeartbeats(true);
+
+                eurekaRegistryService = new EurekaRegistryService(config, eurekaRestClient, kiwiEnvironment, retryer, retryer, retryer, retryer);
+            }
+
+            @Test
+            void shouldStartHeartbeatsWhenNewRegistration() {
+                config.setHeartbeatIntervalInSeconds(1);
+
+                var now = Instant.now();
+                when(kiwiEnvironment.currentInstant()).thenReturn(now);
+
+                var noContentResponse = ResponseMock.simulateInbound(Response.noContent().build());
+                var appId = f("test-service-{}", APP_TIMESTAMP_FORMATTER.format(now)).toUpperCase(Locale.getDefault());
+                when(eurekaRestClient.register(eq(config.getRegistryUrls()), eq(appId), any(EurekaInstance.class)))
+                    .thenReturn(noContentResponse);
+
+                var instance = ServiceInstance.builder()
+                    .serviceName("test-service")
+                    .hostName("localhost")
+                    .status(ServiceInstance.Status.UP)
+                    .ports(List.of(Port.of(8080, Port.PortType.APPLICATION, Port.Security.SECURE)))
+                    .paths(ServicePaths.builder().build())
+                    .description("The best service")
+                    .version("42.0.1")
+                    .commitRef("abcdef")
+                    .build();   
+
+                var eurekaInstance = JSON_HELPER.convertToMap(EurekaInstance.fromServiceInstance(instance).withApp(appId));
+                var okResponse = ResponseMock.simulateInbound(Response.ok(Map.of("instance", eurekaInstance)).build());    
+                when(eurekaRestClient.findInstance(config.getRegistryUrls(), appId, "localhost"))
+                    .thenReturn(okResponse);
+
+                when(eurekaRestClient.sendHeartbeat(config.getRegistryUrls(), appId, "localhost")).thenReturn(Response.ok().build());
+
+                var registeredInstance = eurekaRegistryService.register(instance);
+
+                assertThat(registeredInstance).isNotNull();
+                assertThat(registeredInstance.getNativeRegistryData()).isNullOrEmpty();
+
+                verifyHeartbeats(10, 2);
+            }
+
+            private void verifyHeartbeats(int maxWaitTimeInSeconds, int expectedCount) {
+                await().atMost(maxWaitTimeInSeconds, TimeUnit.SECONDS).until(() -> {
+                    LOG.info("Heartbeat count: {}", eurekaRegistryService.heartbeatCount.get());
+                    return eurekaRegistryService.heartbeatCount.get() > expectedCount;
+                });
+                assertThat(eurekaRegistryService.heartbeatCount.get()).isGreaterThan(expectedCount);
+            }
+        }
+    
     }
 }

--- a/src/test/java/org/kiwiproject/registry/eureka/util/EurekaTestDataHelper.java
+++ b/src/test/java/org/kiwiproject/registry/eureka/util/EurekaTestDataHelper.java
@@ -32,6 +32,7 @@ import org.testcontainers.images.builder.ImageFromDockerfile;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.core.Response;
 
@@ -55,7 +56,7 @@ public class EurekaTestDataHelper {
     }
 
     public static void waitForEurekaToStart(String baseUrl) {
-        var client = ClientBuilder.newClient().register(GZipEncoder.class);
+        var client = newJerseyClient();
         await().atMost(1, MINUTES).until(() -> {
             var response = client.target(baseUrl)
                     .path("apps")
@@ -88,7 +89,7 @@ public class EurekaTestDataHelper {
     }
 
     public static void loadInstanceAndWaitForRegistration(EurekaInstance instance, String baseUrl) {
-        var client = ClientBuilder.newClient().register(GZipEncoder.class);
+        var client = newJerseyClient();
 
         var loadResponse = client.target(baseUrl)
                 .path("apps/{appId}")
@@ -119,7 +120,7 @@ public class EurekaTestDataHelper {
     }
 
     public static void clearAllInstances(String baseUrl) {
-        var client = ClientBuilder.newClient().register(GZipEncoder.class);
+        var client = newJerseyClient();
 
         var instances = findAllInstances(baseUrl);
 
@@ -137,9 +138,7 @@ public class EurekaTestDataHelper {
     }
 
     private static List<EurekaInstance> findAllInstances(String baseUrl) {
-        var client = ClientBuilder.newClient().register(GZipEncoder.class);
-
-        var response = client.target(baseUrl)
+        var response = newJerseyClient().target(baseUrl)
                 .path("apps")
                 .request()
                 .accept(APPLICATION_JSON_TYPE)
@@ -165,9 +164,7 @@ public class EurekaTestDataHelper {
     }
 
     private static Response findApplication(String appId, String baseUrl) {
-        var client = ClientBuilder.newClient().register(GZipEncoder.class);
-
-        return client.target(baseUrl)
+        return newJerseyClient().target(baseUrl)
                 .path("apps/{appId}")
                 .resolveTemplate("appId", appId)
                 .request()
@@ -175,4 +172,7 @@ public class EurekaTestDataHelper {
                 .get();
     }
 
+    public static Client newJerseyClient() {
+        return ClientBuilder.newClient().register(GZipEncoder.class);
+    }
 }

--- a/src/test/java/org/kiwiproject/registry/eureka/util/EurekaTestDataHelper.java
+++ b/src/test/java/org/kiwiproject/registry/eureka/util/EurekaTestDataHelper.java
@@ -43,7 +43,6 @@ public class EurekaTestDataHelper {
     public static ImageFromDockerfile eurekaImage() {
         return new ImageFromDockerfile()
                 .withFileFromClasspath("Dockerfile", "eureka-server/Dockerfile")
-                .withFileFromClasspath("eureka-server-1.10.17.war", "eureka-server/eureka-server-1.10.17.war")
                 .withFileFromClasspath("config.properties", "eureka-server/config.properties")
                 .withFileFromClasspath("eureka-client-test.properties", "eureka-server/eureka-client-test.properties")
                 .withFileFromClasspath("eureka-server-test.properties", "eureka-server/eureka-server-test.properties");

--- a/src/test/java/org/kiwiproject/registry/eureka/util/EurekaTestDataHelper.java
+++ b/src/test/java/org/kiwiproject/registry/eureka/util/EurekaTestDataHelper.java
@@ -1,0 +1,169 @@
+package org.kiwiproject.registry.eureka.util;
+
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static javax.ws.rs.client.Entity.json;
+import static javax.ws.rs.core.HttpHeaders.CONTENT_TYPE;
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON_TYPE;
+import static org.awaitility.Awaitility.await;
+import static org.kiwiproject.base.KiwiStrings.f;
+import static org.kiwiproject.jaxrs.KiwiResponses.successful;
+import static org.kiwiproject.registry.eureka.common.EurekaResponseParser.parseEurekaApplicationsResponse;
+import static org.kiwiproject.registry.eureka.common.EurekaResponseParser.parseEurekaInstanceResponse;
+import static org.kiwiproject.registry.eureka.config.EurekaRegistrationConfig.DEFAULT_LEASE_EXPIRATION_DURATION_SECONDS;
+import static org.kiwiproject.registry.eureka.config.EurekaRegistrationConfig.DEFAULT_LEASE_RENEWAL_INTERVAL_SECONDS;
+import static org.kiwiproject.registry.eureka.server.EurekaRegistryService.DEFAULT_DATA_CENTER_INFO_CLASS;
+import static org.kiwiproject.registry.eureka.server.EurekaRegistryService.DEFAULT_DATA_CENTER_NAME;
+import static org.kiwiproject.registry.eureka.server.EurekaRegistryService.LEASE_DURATION_IN_SECONDS;
+import static org.kiwiproject.registry.eureka.server.EurekaRegistryService.LEASE_RENEWAL_INTERVAL_IN_SECONDS;
+import static org.kiwiproject.test.jaxrs.JaxrsTestHelper.assertNoContentResponse;
+import static org.kiwiproject.test.jaxrs.JaxrsTestHelper.assertNotFoundResponse;
+import static org.kiwiproject.test.jaxrs.JaxrsTestHelper.assertOkResponse;
+
+import lombok.experimental.UtilityClass;
+import lombok.extern.slf4j.Slf4j;
+import org.glassfish.jersey.message.GZipEncoder;
+import org.kiwiproject.jaxrs.KiwiGenericTypes;
+import org.kiwiproject.registry.eureka.common.EurekaInstance;
+import org.kiwiproject.registry.eureka.common.EurekaResponseParser;
+import org.kiwiproject.registry.eureka.config.EurekaConfig;
+import org.kiwiproject.registry.model.ServiceInstance;
+import org.kiwiproject.registry.util.ServiceInfoHelper;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.images.builder.ImageFromDockerfile;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.core.Response;
+
+@UtilityClass
+@Slf4j
+public class EurekaTestDataHelper {
+
+    public static ImageFromDockerfile eurekaImage() {
+        return new ImageFromDockerfile()
+                .withFileFromClasspath("Dockerfile", "eureka-server/Dockerfile")
+                .withFileFromClasspath("eureka-server-1.10.17.war", "eureka-server/eureka-server-1.10.17.war")
+                .withFileFromClasspath("config.properties", "eureka-server/config.properties")
+                .withFileFromClasspath("eureka-client-test.properties", "eureka-server/eureka-client-test.properties")
+                .withFileFromClasspath("eureka-server-test.properties", "eureka-server/eureka-server-test.properties");
+    }
+
+    public static String eurekaUrl(GenericContainer container) {
+        var host = container.getHost();
+        var port = container.getFirstMappedPort();
+        return f("http://{}:{}/eureka/v2", host, port);
+    }
+
+    public static void waitForEurekaToStart(String baseUrl) {
+        var client = ClientBuilder.newClient().register(GZipEncoder.class);
+        await().atMost(1, MINUTES).until(() -> {
+            var response = client.target(baseUrl)
+                    .path("apps")
+                    .request()
+                    .accept(APPLICATION_JSON_TYPE)
+                    .get();
+            LOG.info("Waiting for Eureka to start.  Status: {}", response.getStatus());
+            return successful(response);
+        });
+    }
+
+    public static EurekaInstance sampleInstance(String appName, String hostname, String vipAddress, ServiceInstance.Status status) {
+        var service = ServiceInstance.fromServiceInfo(ServiceInfoHelper.buildTestServiceInfo(vipAddress, hostname, new HashMap<>()))
+                .withStatus(status);
+
+        return EurekaInstance.fromServiceInstance(service)
+                .withApp(appName)
+                .withDataCenterInfo(Map.of(
+                        "name", DEFAULT_DATA_CENTER_NAME,
+                        "@class", DEFAULT_DATA_CENTER_INFO_CLASS
+                ))
+                .withLeaseInfo(Map.of(
+                        LEASE_DURATION_IN_SECONDS, DEFAULT_LEASE_EXPIRATION_DURATION_SECONDS,
+                        LEASE_RENEWAL_INTERVAL_IN_SECONDS, DEFAULT_LEASE_RENEWAL_INTERVAL_SECONDS
+                ));
+    }
+
+    public static void loadInstanceAndWaitForRegistration(String baseUrl) {
+        loadInstanceAndWaitForRegistration(sampleInstance("TEST-APP", "localhost", "TEST-APP", ServiceInstance.Status.UP), baseUrl);
+    }
+
+    public static void loadInstanceAndWaitForRegistration(EurekaInstance instance, String baseUrl) {
+        var client = ClientBuilder.newClient().register(GZipEncoder.class);
+
+        var loadResponse = client.target(baseUrl)
+                .path("apps/{appId}")
+                .resolveTemplate("appId", instance.getApp())
+                .request()
+                .accept(APPLICATION_JSON_TYPE)
+                .header(CONTENT_TYPE, APPLICATION_JSON)
+                .post(json(Map.of("instance", instance)));
+
+        assertNoContentResponse(loadResponse);
+
+        await().atMost(1, MINUTES).until(() -> {
+            var response = client.target(baseUrl)
+                    .path("apps")
+                    .request()
+                    .accept(APPLICATION_JSON_TYPE)
+                    .get();
+
+            if (successful(response)) {
+                var eurekaResponse = response.readEntity(KiwiGenericTypes.MAP_OF_STRING_TO_OBJECT_GENERIC_TYPE);
+                var apps = EurekaResponseParser.parseEurekaApplicationsResponse(eurekaResponse);
+
+                return apps.size() > 0;
+            }
+
+            return false;
+        });
+    }
+
+    public static void clearAllInstances(String baseUrl) {
+        var client = ClientBuilder.newClient().register(GZipEncoder.class);
+
+        var response = client.target(baseUrl)
+                .path("apps")
+                .request()
+                .accept(APPLICATION_JSON_TYPE)
+                .get();
+
+        if (successful(response)) {
+            var eurekaResponse = response.readEntity(KiwiGenericTypes.MAP_OF_STRING_TO_OBJECT_GENERIC_TYPE);
+            var apps = EurekaResponseParser.parseEurekaApplicationsResponse(eurekaResponse);
+
+            apps.forEach(instance -> {
+                client.target(baseUrl)
+                        .path("apps/{appId}/{instanceId}")
+                        .resolveTemplate("appId", instance.getApp())
+                        .resolveTemplate("instanceId", instance.getInstanceId())
+                        .request()
+                        .accept(APPLICATION_JSON_TYPE)
+                        .delete();
+            });
+        }
+    }
+
+    public static void assertApplicationIsRegistered(String appId, String baseUrl) {
+        assertOkResponse(findApplication(appId, baseUrl));
+    }
+
+    public static void assertApplicationIsNotRegistered(String appId, String baseUrl) {
+        assertNotFoundResponse(findApplication(appId, baseUrl));
+    }
+
+    private static Response findApplication(String appId, String baseUrl) {
+        var client = ClientBuilder.newClient().register(GZipEncoder.class);
+
+        return client.target(baseUrl)
+                .path("apps/{appId}")
+                .resolveTemplate("appId", appId)
+                .request()
+                .accept(APPLICATION_JSON_TYPE)
+                .get();
+    }
+
+}

--- a/src/test/java/org/kiwiproject/registry/eureka/util/EurekaTestDataHelper.java
+++ b/src/test/java/org/kiwiproject/registry/eureka/util/EurekaTestDataHelper.java
@@ -7,7 +7,6 @@ import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON_TYPE;
 import static org.awaitility.Awaitility.await;
 import static org.kiwiproject.base.KiwiStrings.f;
-import static org.kiwiproject.collect.KiwiLists.isNotNullOrEmpty;
 import static org.kiwiproject.jaxrs.KiwiResponses.successful;
 import static org.kiwiproject.registry.eureka.config.EurekaRegistrationConfig.DEFAULT_LEASE_EXPIRATION_DURATION_SECONDS;
 import static org.kiwiproject.registry.eureka.config.EurekaRegistrationConfig.DEFAULT_LEASE_RENEWAL_INTERVAL_SECONDS;
@@ -19,13 +18,8 @@ import static org.kiwiproject.test.jaxrs.JaxrsTestHelper.assertNoContentResponse
 import static org.kiwiproject.test.jaxrs.JaxrsTestHelper.assertNotFoundResponse;
 import static org.kiwiproject.test.jaxrs.JaxrsTestHelper.assertOkResponse;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import javax.ws.rs.client.ClientBuilder;
-import javax.ws.rs.core.Response;
-
+import lombok.experimental.UtilityClass;
+import lombok.extern.slf4j.Slf4j;
 import org.glassfish.jersey.message.GZipEncoder;
 import org.kiwiproject.jaxrs.KiwiGenericTypes;
 import org.kiwiproject.registry.eureka.common.EurekaInstance;
@@ -35,8 +29,11 @@ import org.kiwiproject.registry.util.ServiceInfoHelper;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.images.builder.ImageFromDockerfile;
 
-import lombok.experimental.UtilityClass;
-import lombok.extern.slf4j.Slf4j;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.core.Response;
 
 @UtilityClass
 @Slf4j
@@ -124,7 +121,7 @@ public class EurekaTestDataHelper {
     public static void clearAllInstances(String baseUrl) {
         var client = ClientBuilder.newClient().register(GZipEncoder.class);
 
-        var instances = await().atMost(1, MINUTES).until(() -> findAllInstances(baseUrl), all -> isNotNullOrEmpty(all));
+        var instances = findAllInstances(baseUrl);
 
         LOG.info("Found {} instances to delete", instances.size());
         instances.forEach(instance -> {

--- a/src/test/java/org/kiwiproject/registry/util/ResponseMock.java
+++ b/src/test/java/org/kiwiproject/registry/util/ResponseMock.java
@@ -1,0 +1,40 @@
+package org.kiwiproject.registry.util;
+
+import static org.mockito.AdditionalAnswers.answer;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.spy;
+
+import javax.ws.rs.core.GenericType;
+import javax.ws.rs.core.Response;
+
+import org.mockito.ArgumentMatchers;
+
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public class ResponseMock {
+    
+    /**
+     * @implNote The entity that is added to the original response must be the same type that is being ultimately read. There will not be any conversions.
+     */
+    public static Response simulateInbound(Response originalResponse) {
+        var responseToReturn = spy(originalResponse);
+       
+        doAnswer(answer((Class<?> type) -> readEntity(responseToReturn, type)))
+          .when(responseToReturn)
+          .readEntity(ArgumentMatchers.<Class<?>>any());
+
+        doAnswer(answer((GenericType<?> type) -> readEntity(responseToReturn, type.getRawType())))
+          .when(responseToReturn)
+          .readEntity(ArgumentMatchers.<GenericType<?>>any());
+
+        return responseToReturn;
+      }
+       
+      // use the getEntity from the real object as
+      // the readEntity of the mock
+      @SuppressWarnings("unchecked")
+      private static <T> T readEntity(Response realResponse, Class<T> t) {
+        return (T)realResponse.getEntity();
+      }
+}

--- a/src/test/resources/eureka-server/Dockerfile
+++ b/src/test/resources/eureka-server/Dockerfile
@@ -1,10 +1,11 @@
 FROM netflixoss/tomcat:7.0.64
 
-RUN mkdir -p /tomcat/webapps/eureka
-
-ADD eureka-server-1.10.17.war /tomcat/webapps/eureka/
-
-RUN cd /tomcat/webapps/eureka && jar xf eureka-server-1.10.17.war && rm eureka-server-1.10.17.war
+RUN cd /tomcat/webapps &&\
+  mkdir eureka &&\
+  cd eureka &&\
+  wget -q https://repo1.maven.org/maven2/com/netflix/eureka/eureka-server/1.10.17/eureka-server-1.10.17.war &&\
+  jar xf eureka-server-1.10.17.war &&\
+  rm eureka-server-1.10.17.war
 
 ADD config.properties /tomcat/webapps/eureka/WEB-INF/classes/config.properties
 ADD eureka-client-test.properties /tomcat/webapps/eureka/WEB-INF/classes/eureka-client-test.properties

--- a/src/test/resources/eureka-server/Dockerfile
+++ b/src/test/resources/eureka-server/Dockerfile
@@ -1,0 +1,17 @@
+FROM netflixoss/tomcat:7.0.64
+
+RUN mkdir -p /tomcat/webapps/eureka
+
+ADD eureka-server-1.10.17.war /tomcat/webapps/eureka/
+
+RUN cd /tomcat/webapps/eureka && jar xf eureka-server-1.10.17.war && rm eureka-server-1.10.17.war
+
+ADD config.properties /tomcat/webapps/eureka/WEB-INF/classes/config.properties
+ADD eureka-client-test.properties /tomcat/webapps/eureka/WEB-INF/classes/eureka-client-test.properties
+ADD eureka-server-test.properties /tomcat/webapps/eureka/WEB-INF/classes/eureka-server-test.properties
+
+EXPOSE 8080
+
+ENTRYPOINT ["/tomcat/bin/catalina.sh"]
+
+CMD ["run"]

--- a/src/test/resources/eureka-server/config.properties
+++ b/src/test/resources/eureka-server/config.properties
@@ -1,0 +1,2 @@
+archaius.deployment.applicationId=eureka
+archaius.deployment.environment=test

--- a/src/test/resources/eureka-server/eureka-client-test.properties
+++ b/src/test/resources/eureka-server/eureka-client-test.properties
@@ -1,0 +1,2 @@
+eureka.serviceUrl.default=http://localhost:8080/eureka/v2/
+eureka.vipAddress=eureka

--- a/src/test/resources/eureka-server/eureka-server-test.properties
+++ b/src/test/resources/eureka-server/eureka-server-test.properties
@@ -1,0 +1,4 @@
+eureka.enableSelfPreservation=false
+eureka.registration.enabled=false
+eureka.numberRegistrySyncRetries=0
+eureka.waitTimeInMsWhenSyncEmpty=0


### PR DESCRIPTION
Replace embedded eureka with testcontainers running eureka in a container

* I did have to remove a few tests related to heartbeats as I don't have as much insight into the interworkings of Eureka this way and expecting things to happen in a parallel world is very challenging.
* We currently have the eureka war in the test/resources.  We could set the Dockerfile to download the war but it will slow down the tests even more
* Tests are slower now which makes sense, it has to spin up a container
* One other option would be to release a new eureka container under kiwi project's domain and use that.

Closes #234 