### PR TITLE
Remove redundant UnstableApiUsage warning suppression annotations

### DIFF
--- a/src/test/java/org/kiwiproject/registry/consul/client/ConsulRegistryClientTest.java
+++ b/src/test/java/org/kiwiproject/registry/consul/client/ConsulRegistryClientTest.java
@@ -38,7 +38,6 @@ class ConsulRegistryClientTest {
     private ConsulRegistryClient client;
     private ConsulConfig config;
 
-    @SuppressWarnings("UnstableApiUsage")
     @BeforeEach
     void setUp() {
         var consul = Consul.builder()

--- a/src/test/java/org/kiwiproject/registry/consul/server/ConsulRegistryServiceIntegrationTest.java
+++ b/src/test/java/org/kiwiproject/registry/consul/server/ConsulRegistryServiceIntegrationTest.java
@@ -37,6 +37,7 @@ class ConsulRegistryServiceIntegrationTest {
     // NOTE:
     // Even though this extension uses an AfterAllCallback, it can NOT be static as running all the tests fail.
     // I'm not sure if this is something with the extension or with the Nested test classes
+    // TODO Re-evaluate the above note. IntelliJ also flagged the same thing in ConsulRegistryClientTest
     @RegisterExtension
     final ConsulExtension consulExtension = new ConsulExtension(ConsulStarterHelper.buildStarterConfigWithEnvironment());
 
@@ -45,7 +46,6 @@ class ConsulRegistryServiceIntegrationTest {
     private Consul consul;
     private ConsulRegistrationConfig config;
 
-    @SuppressWarnings("UnstableApiUsage")
     @BeforeEach
     void setUp() {
         consul = Consul.builder()


### PR DESCRIPTION
* The HostAndPort class is no longer marked as "beta" in Guava, so
  the SuppressWarnings annotations can be removed
* Add a TODO regarding the IntelliJ warning that ConsulExtension can
  be static.