### PR TITLE
Code cleanup: use existing local variable in ConsulStarterHelper

### DIFF
--- a/src/test/java/org/kiwiproject/registry/consul/util/ConsulStarterHelper.java
+++ b/src/test/java/org/kiwiproject/registry/consul/util/ConsulStarterHelper.java
@@ -35,7 +35,7 @@ public class ConsulStarterHelper {
                 if (!Files.exists(downloadPath)) {
                     Files.createDirectory(downloadPath);
                 }
-                starter.withConsulBinaryDownloadDirectory(Path.of(downloadLocation));
+                starter.withConsulBinaryDownloadDirectory(downloadPath);
             } catch (IOException e) {
                 LOG.error("Unable to create consul download directory going to use the default", e);
             }


### PR DESCRIPTION
The downloadPath local variable can be re-used instead of doing the
same Path.of(downloadLocation) in #buildStarterConfigWithEnvironment