### PR TITLE
Make static GenericContainer fields final in tests

### DIFF
--- a/src/test/java/org/kiwiproject/registry/eureka/client/EurekaRegistryClientTest.java
+++ b/src/test/java/org/kiwiproject/registry/eureka/client/EurekaRegistryClientTest.java
@@ -39,7 +39,8 @@ import javax.ws.rs.core.Response;
 class EurekaRegistryClientTest {
 
     @Container
-    public static GenericContainer eureka = new GenericContainer(eurekaImage())
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    public static final GenericContainer EUREKA = new GenericContainer(eurekaImage())
             .withExposedPorts(8080)
             .withLogConsumer(new Slf4jLogConsumer(LOG));
 
@@ -49,7 +50,7 @@ class EurekaRegistryClientTest {
     @BeforeEach
     void setUp() {
         config = new EurekaConfig();
-        config.setRegistryUrls(EurekaTestDataHelper.eurekaUrl(eureka));
+        config.setRegistryUrls(EurekaTestDataHelper.eurekaUrl(EUREKA));
 
         client = new EurekaRegistryClient(config, new EurekaRestClient());
 

--- a/src/test/java/org/kiwiproject/registry/eureka/common/EurekaRestClientTest.java
+++ b/src/test/java/org/kiwiproject/registry/eureka/common/EurekaRestClientTest.java
@@ -37,7 +37,8 @@ import java.util.Map;
 class EurekaRestClientTest {
 
     @Container
-    public static GenericContainer eureka = new GenericContainer(eurekaImage())
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    public static final GenericContainer EUREKA = new GenericContainer(eurekaImage())
             .withExposedPorts(8080)
             .withLogConsumer(new Slf4jLogConsumer(LOG));
 
@@ -47,7 +48,7 @@ class EurekaRestClientTest {
     @BeforeEach
     void setUp() {
         client = new EurekaRestClient();
-        eurekaBaseUrl = EurekaTestDataHelper.eurekaUrl(eureka);
+        eurekaBaseUrl = EurekaTestDataHelper.eurekaUrl(EUREKA);
 
         EurekaTestDataHelper.waitForEurekaToStart(eurekaBaseUrl);
     }

--- a/src/test/java/org/kiwiproject/registry/eureka/server/EurekaRegistryServiceIntegrationTest.java
+++ b/src/test/java/org/kiwiproject/registry/eureka/server/EurekaRegistryServiceIntegrationTest.java
@@ -50,7 +50,8 @@ import java.util.concurrent.TimeUnit;
 class EurekaRegistryServiceIntegrationTest {
 
     @Container
-    public static GenericContainer eureka = new GenericContainer(eurekaImage())
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    public static final GenericContainer EUREKA = new GenericContainer(eurekaImage())
             .withExposedPorts(8080)
             .withLogConsumer(new Slf4jLogConsumer(LOG));
 
@@ -66,7 +67,7 @@ class EurekaRegistryServiceIntegrationTest {
 
         config = new EurekaRegistrationConfig();
         config.setHeartbeatIntervalInSeconds(1);
-        config.setRegistryUrls(EurekaTestDataHelper.eurekaUrl(eureka));
+        config.setRegistryUrls(EurekaTestDataHelper.eurekaUrl(EUREKA));
         config.setTrackHeartbeats(true);
 
         service = new EurekaRegistryService(config, client, environment);

--- a/src/test/java/org/kiwiproject/registry/eureka/util/EurekaTestDataHelper.java
+++ b/src/test/java/org/kiwiproject/registry/eureka/util/EurekaTestDataHelper.java
@@ -29,12 +29,12 @@ import org.kiwiproject.registry.util.ServiceInfoHelper;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.images.builder.ImageFromDockerfile;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.core.Response;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 @UtilityClass
 @Slf4j
@@ -48,7 +48,7 @@ public class EurekaTestDataHelper {
                 .withFileFromClasspath("eureka-server-test.properties", "eureka-server/eureka-server-test.properties");
     }
 
-    public static String eurekaUrl(GenericContainer container) {
+    public static String eurekaUrl(GenericContainer<?> container) {
         var host = container.getHost();
         var port = container.getFirstMappedPort();
         return f("http://{}:{}/eureka/v2", host, port);


### PR DESCRIPTION
* Make the static GenericContainer fields in tests final too
* Rename the GenericContainer fields with ALL_UPPERCASE to be idiomatic
* Suppress generics warnings on GenericContainer; there's nothing we
  can parameterize it with that makes sense, so ignore
* Make EurekaTestDataHelper#eurekaUrl accept GenericContainer<?> to
  make the raw types warning go away.