### PR TITLE
Ensure Eureka responses are always closed

### DIFF
--- a/src/main/java/org/kiwiproject/registry/eureka/server/EurekaHeartbeatSender.java
+++ b/src/main/java/org/kiwiproject/registry/eureka/server/EurekaHeartbeatSender.java
@@ -4,6 +4,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static java.time.format.DateTimeFormatter.ISO_INSTANT;
 import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
+import static org.kiwiproject.jaxrs.KiwiResponses.closeQuietly;
 import static org.kiwiproject.jaxrs.KiwiResponses.successful;
 import static org.kiwiproject.logging.LazyLogParameterSupplier.lazy;
 import static org.kiwiproject.registry.eureka.server.EurekaHeartbeatSender.FailureHandlerResult.CANNOT_SELF_HEAL;
@@ -23,10 +24,10 @@ import org.kiwiproject.registry.eureka.common.EurekaUrlProvider;
 import org.kiwiproject.registry.model.ServiceInstance;
 import org.kiwiproject.retry.KiwiRetryerPredicates;
 
-import java.time.Duration;
-import java.time.Instant;
 import javax.annotation.Nullable;
 import javax.ws.rs.core.Response;
+import java.time.Duration;
+import java.time.Instant;
 
 @Slf4j
 class EurekaHeartbeatSender implements Runnable {
@@ -74,6 +75,9 @@ class EurekaHeartbeatSender implements Runnable {
                     registeredInstance.getInstanceId());
         } catch (Exception e) {
             exception = e;
+        } finally {
+            // It's safe to close the response since we don't need the entity
+            closeQuietly(response);
         }
 
         if (nonNull(response) && successful(response)) {


### PR DESCRIPTION
* Add a 'finally' block in EurekaHeartbeatSender#run that closes the
  response. KiwiResponses#closeQuietly ignores null arguments so there
  is no need for a guard around the call.
* In EurekaRegistryService#registerWithEureka, refactor the code to be
  more clear. IntelliJ was complaining that we're not using
  try-with-resources for the Response. Change code to use
  Optionals#ifPresentOrElseThrow so that the action for success and
  failure cases are clear. Also, extract code to read entity "safely"
  into a helper method and call that. Reading the entity ensures the
  response is closed.
* In EurekaRegistryService#waitForInstanceToBeRegistered, rename
  'response' to 'responseOptional' to make it clear the type is
  really an Optional containing a Response. Do the same in updateStatus
  and unregisterFromEureka.
* Explicitly close the Response in updateStatus and unregisterFromEureka
  since we do not read the response entity in those methods.
* Add some javadoc to EurekaRegistryService#eurekaCallRetrySupplier
  explaining that the caller must close the Response if the Supplier
  returns one. Also extract the code to read the response entity to
  a local variable, making it more clear that the response is closed
  (via the readEntity method).

Fixes #244