### PR TITLE
Add ability to configure Eureka HTTP call retry log levels

### DIFF
--- a/src/main/java/org/kiwiproject/registry/eureka/client/EurekaRegistryClient.java
+++ b/src/main/java/org/kiwiproject/registry/eureka/client/EurekaRegistryClient.java
@@ -62,6 +62,8 @@ public class EurekaRegistryClient implements RegistryClient {
         var maxAttempts = urlProvider.urlCount() * EUREKA_ATTEMPT_MULTIPLIER;
         this.clientRetryer = KiwiRetryer.<Response>builder()
                 .retryerId(config.getRetryId())
+                .processingLogLevel(config.getRetryProcessingLogLevel())
+                .exceptionLogLevel(config.getRetryExceptionLogLevel())
                 .exceptionPredicates(List.of(
                         CONNECTION_ERROR, NO_ROUTE_TO_HOST, SOCKET_TIMEOUT, SSL_HANDSHAKE_ERROR, UNKNOWN_HOST, temporaryServerSideStatusCodes()
                 ))

--- a/src/main/java/org/kiwiproject/registry/eureka/config/EurekaConfig.java
+++ b/src/main/java/org/kiwiproject/registry/eureka/config/EurekaConfig.java
@@ -11,13 +11,14 @@ import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 
 import org.kiwiproject.jackson.ser.ListToCsvStringDeserializer;
+import org.slf4j.event.Level;
 
 import javax.validation.constraints.NotBlank;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
- *  Base configuration class for Eureka registry client configuration.
+ * Base configuration class for Eureka registry client configuration.
  */
 @Getter
 @Setter
@@ -68,6 +69,17 @@ public class EurekaConfig {
      * integer, e.g. "EurekaRegistryClient-1", "EurekaRegistryClient-2", etc.
      */
     private String retryId = retryId(INSTANCE_COUNT.incrementAndGet());
+
+    /**
+     * The log level to use when logging HTTP call attempts. The default is DEBUG.
+     */
+    private Level retryProcessingLogLevel = Level.DEBUG;
+
+    /**
+     * The log level to use when logging HTTP call attempts that fail with an exception.
+     * The default is WARN.
+     */
+    private Level retryExceptionLogLevel = Level.WARN;
 
     /**
      * @return comma separated list of urls pointing to Eureka servers, with domains replaced if {@code domainOverride}

--- a/src/test/java/org/kiwiproject/registry/eureka/config/EurekaConfigTest.java
+++ b/src/test/java/org/kiwiproject/registry/eureka/config/EurekaConfigTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.Test;
 import org.kiwiproject.json.JsonHelper;
 import org.kiwiproject.test.util.Fixtures;
 import org.kiwiproject.yaml.YamlHelper;
+import org.slf4j.event.Level;
 
 import java.util.List;
 
@@ -47,6 +48,18 @@ class EurekaConfigTest {
 
     private static int extractRetryIdUniquePart(String retryId) {
         return Integer.parseInt(retryId.split("-")[1]);
+    }
+
+    @Test
+    void shouldDefaultRetryProcessingLogLevelToDEBUG() {
+        var config = new EurekaConfig();
+        assertThat(config.getRetryProcessingLogLevel()).isEqualTo(Level.DEBUG);
+    }
+
+    @Test
+    void shouldDefaultRetryExceptionLogLevelToWARN() {
+        var config = new EurekaConfig();
+        assertThat(config.getRetryExceptionLogLevel()).isEqualTo(Level.WARN);
     }
 
     @Nested


### PR DESCRIPTION
* Add retryProcessingLogLevel and retryExceptionLogLevel to EurekaConfig
* Pass the configured log levels to the KiwiRetryer in EurekaRegistryClient

Closes #275