### PR TITLE
Make ServiceInstance and ServicePaths Value classes

### DIFF
--- a/src/main/java/org/kiwiproject/registry/model/ServiceInstance.java
+++ b/src/main/java/org/kiwiproject/registry/model/ServiceInstance.java
@@ -3,7 +3,7 @@ package org.kiwiproject.registry.model;
 import static java.util.Objects.isNull;
 
 import lombok.Builder;
-import lombok.Getter;
+import lombok.Value;
 import lombok.With;
 import org.kiwiproject.registry.config.ServiceInfo;
 import org.kiwiproject.registry.model.Port.PortType;
@@ -16,7 +16,7 @@ import java.util.Map;
 /**
  * Model containing information about a running service
  */
-@Getter
+@Value
 @Builder(toBuilder = true)
 public class ServiceInstance {
 
@@ -30,29 +30,29 @@ public class ServiceInstance {
     }
 
     @With
-    private final String instanceId;
+    String instanceId;
 
     @With
-    private final Status status;
+    Status status;
 
-    private final String serviceName;
+    String serviceName;
 
     @With
-    private final String hostName;
+    String hostName;
 
-    private final String ip;
-    private final List<Port> ports;
-    private final ServicePaths paths;
-    private final String commitRef;
-    private final String description;
-    private final String version;
-    private final Instant upSince;
+    String ip;
+    List<Port> ports;
+    ServicePaths paths;
+    String commitRef;
+    String description;
+    String version;
+    Instant upSince;
 
     /**
      * Used to store extra data in a discovery service for this instance
      */
     @With
-    private final Map<String, String> metadata;
+    Map<String, String> metadata;
 
     /**
      * Used to store native registry data that includes data mapped into {@link ServiceInstance} as well as any
@@ -60,7 +60,7 @@ public class ServiceInstance {
      * specifies to include native data.
      */
     @With
-    private final Map<String, Object> nativeRegistryData;
+    Map<String, Object> nativeRegistryData;
 
     /**
      * Returns a new {@code ServiceInstanceBuilder} built from a given {@link ServiceInfo}.

--- a/src/main/java/org/kiwiproject/registry/model/ServicePaths.java
+++ b/src/main/java/org/kiwiproject/registry/model/ServicePaths.java
@@ -1,13 +1,13 @@
 package org.kiwiproject.registry.model;
 
 import lombok.Builder;
-import lombok.Getter;
+import lombok.Value;
 
 /**
  * Model defining various known paths used by services
  */
+@Value
 @Builder
-@Getter
 @SuppressWarnings({"java:S1075"})  // Sonar S1075: URIs should not be hardcoded
 public class ServicePaths {
 
@@ -27,12 +27,12 @@ public class ServicePaths {
     public static final String DEFAULT_HEALTHCHECK_PATH = "/healthcheck";
 
     @Builder.Default
-    private String homePagePath = DEFAULT_HOMEPAGE_PATH;
+    String homePagePath = DEFAULT_HOMEPAGE_PATH;
 
     @Builder.Default
-    private String statusPath = DEFAULT_STATUS_PATH;
+    String statusPath = DEFAULT_STATUS_PATH;
 
     @Builder.Default
-    private String healthCheckPath = DEFAULT_HEALTHCHECK_PATH;
+    String healthCheckPath = DEFAULT_HEALTHCHECK_PATH;
 
 }


### PR DESCRIPTION
CodeQL complained about default toString() implementations, but these classes can and probably should be "Value" classes with equals, hashCode, and toString. Use Lombok Value annotation to make this easy. Remove "private" and "final" modifiers since Lombok does that for us.

Fixes #295