### PR TITLE
Catch NumberFormatExceptions; rethrow as IllegalStateException

### DIFF
--- a/src/test/java/org/kiwiproject/registry/consul/client/ConsulRegistryClientTest.java
+++ b/src/test/java/org/kiwiproject/registry/consul/client/ConsulRegistryClientTest.java
@@ -1,6 +1,7 @@
 package org.kiwiproject.registry.consul.client;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 import static org.assertj.core.api.Assertions.tuple;
 import static org.kiwiproject.registry.consul.util.ConsulTestcontainers.consulHostAndPort;
 import static org.kiwiproject.registry.consul.util.ConsulTestcontainers.newConsulContainer;
@@ -212,6 +213,26 @@ class ConsulRegistryClientTest {
             assertThat(instances)
                     .extracting("serviceName")
                     .contains("APPID", "consul");
+        }
+    }
+
+    @Nested
+    class InternalMethods {
+
+        @Test
+        void getAdminPortNumberOrThrow_shouldThrowIllegalState_whenNotANumber() {
+            assertThatIllegalStateException()
+                    .isThrownBy(() -> ConsulRegistryClient.getAdminPortNumberOrThrow(Map.of("adminPort", "Foo")))
+                    .withMessage("adminPort is not a number")
+                    .withCauseExactlyInstanceOf(NumberFormatException.class);
+        }
+
+        @Test
+        void getServiceUpTimestampOrThrow_shouldThrowIllegalState_whenNotANumber() {
+            assertThatIllegalStateException()
+                    .isThrownBy(() -> ConsulRegistryClient.getServiceUpTimestampOrThrow(Map.of("serviceUpTimestamp", "Bar")))
+                    .withMessage("serviceUpTimestamp is not a number")
+                    .withCauseExactlyInstanceOf(NumberFormatException.class);
         }
     }
 }


### PR DESCRIPTION
I know why CodeQL is saying to handle NumberFormatExceptions, and it is probably better to throw IllegalStateException, but it is definitely annoying to try/catch all these. Maybe add some utilities to kiwi...

Fixes #293
Fixes #294