### PR TITLE
Update Docker image name for Consul to hashicorp/consul:1.15

### DIFF
--- a/src/test/java/org/kiwiproject/registry/consul/util/ConsulTestcontainers.java
+++ b/src/test/java/org/kiwiproject/registry/consul/util/ConsulTestcontainers.java
@@ -15,7 +15,7 @@ public class ConsulTestcontainers {
     }
 
     public static DockerImageName consulDockerImageName() {
-        return DockerImageName.parse("consul");
+        return DockerImageName.parse("hashicorp/consul:1.15");
     }
 
     public static HostAndPort consulHostAndPort(ConsulContainer consul) {


### PR DESCRIPTION
This is because of the notice posted to hub.docker.com:

Upcoming in Consul 1.16, we will stop publishing official Dockerhub images and publish only our Verified Publisher images. Users of Docker images should pull from hashicorp/consul instead of consul. Verified Publisher images can be found at
https://hub.docker.com/r/hashicorp/consul.