### PR TITLE
Update parent POM and BOM for JDK 17 and major library updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java_version: ['11', '17', '20']
+        java_version: [ '17', '20' ]
     steps:
       # Check out the project
       - uses: actions/checkout@v3
@@ -33,7 +33,7 @@ jobs:
       # Cache all the things
       - name: Cache SonarCloud packages
         uses: actions/cache@v3
-        if: ${{ env.SONAR_TOKEN != null && env.SONAR_TOKEN != '' && matrix.java_version == '11' }}
+        if: ${{ env.SONAR_TOKEN != null && env.SONAR_TOKEN != '' && matrix.java_version == '17' }}
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         with:
@@ -54,16 +54,16 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
         run: mvn -B -V compile
 
-      # Run tests when Java version > 11 (Sonar runs tests and analysis on JDK 11)
+      # Run tests when Java version > 17 (Sonar runs tests and analysis on JDK 17)
       - name: Run tests
-        if: ${{ matrix.java_version != '11' }}
+        if: ${{ matrix.java_version != '17' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
         run: mvn -B -V verify
 
-      # Run Sonar Analysis (on Java version 11 only)
+      # Run Sonar Analysis (on Java version 17 only)
       - name: Analyze with SonarCloud
-        if: ${{ env.SONAR_TOKEN != null && env.SONAR_TOKEN != '' && matrix.java_version == '11' }}
+        if: ${{ env.SONAR_TOKEN != null && env.SONAR_TOKEN != '' && matrix.java_version == '17' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -33,6 +33,12 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v3
 
+    - name: Set up Java 17
+      uses: actions/setup-java@v3
+      with:
+        distribution: temurin
+        java-version: 17
+
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2
       with:

--- a/pom.xml
+++ b/pom.xml
@@ -4,11 +4,11 @@
     <parent>
         <groupId>org.kiwiproject</groupId>
         <artifactId>kiwi-parent</artifactId>
-        <version>2.0.20</version>
+        <version>3.0.1</version>
     </parent>
 
     <artifactId>service-discovery-client</artifactId>
-    <version>1.2.2-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>
@@ -27,15 +27,15 @@
 
     <properties>
         <!-- Versions for required dependencies -->
-        <kiwi.version>2.7.0</kiwi.version>
-        <kiwi-bom.version>1.1.1</kiwi-bom.version>
+        <kiwi.version>3.0.0</kiwi.version>
+        <kiwi-bom.version>2.0.0</kiwi-bom.version>
 
         <!-- Versions for provided dependencies -->
-        <consul-client.version>0.8.0</consul-client.version>
-        <retrying-again.version>1.0.18</retrying-again.version>
+        <consul-client.version>1.0.0</consul-client.version>
+        <retrying-again.version>2.0.0</retrying-again.version>
 
         <!-- Versions for test dependencies -->
-        <kiwi-test.version>2.4.0</kiwi-test.version>
+        <kiwi-test.version>3.0.0</kiwi-test.version>
         <test-containers.version>1.18.3</test-containers.version>
 
         <!-- Sonar properties -->

--- a/src/main/java/org/kiwiproject/registry/eureka/client/EurekaRegistryClient.java
+++ b/src/main/java/org/kiwiproject/registry/eureka/client/EurekaRegistryClient.java
@@ -12,6 +12,8 @@ import static org.kiwiproject.retry.KiwiRetryerPredicates.SSL_HANDSHAKE_ERROR;
 import static org.kiwiproject.retry.KiwiRetryerPredicates.UNKNOWN_HOST;
 
 import com.google.common.annotations.VisibleForTesting;
+import jakarta.ws.rs.ServerErrorException;
+import jakarta.ws.rs.core.Response;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.kiwiproject.jaxrs.KiwiGenericTypes;
@@ -32,8 +34,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
-import javax.ws.rs.ServerErrorException;
-import javax.ws.rs.core.Response;
 
 /**
  * {@link RegistryClient} implementation for looking up services from Eureka registry server.

--- a/src/main/java/org/kiwiproject/registry/eureka/common/EurekaRestClient.java
+++ b/src/main/java/org/kiwiproject/registry/eureka/common/EurekaRestClient.java
@@ -1,19 +1,19 @@
 package org.kiwiproject.registry.eureka.common;
 
-import static javax.ws.rs.client.Entity.json;
-import static javax.ws.rs.core.HttpHeaders.CONTENT_TYPE;
-import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
-import static javax.ws.rs.core.MediaType.APPLICATION_JSON_TYPE;
+import static jakarta.ws.rs.client.Entity.json;
+import static jakarta.ws.rs.core.HttpHeaders.CONTENT_TYPE;
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON_TYPE;
 
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.core.Response;
 import lombok.AllArgsConstructor;
 import org.glassfish.jersey.client.ClientProperties;
 import org.glassfish.jersey.message.GZipEncoder;
 import org.kiwiproject.registry.model.ServiceInstance;
 
 import java.util.Map;
-import javax.ws.rs.client.Client;
-import javax.ws.rs.client.ClientBuilder;
-import javax.ws.rs.core.Response;
 
 @AllArgsConstructor
 public class EurekaRestClient {

--- a/src/main/java/org/kiwiproject/registry/eureka/config/EurekaConfig.java
+++ b/src/main/java/org/kiwiproject/registry/eureka/config/EurekaConfig.java
@@ -6,14 +6,13 @@ import static org.kiwiproject.base.KiwiPreconditions.checkArgumentNotNull;
 import static org.kiwiproject.net.KiwiUrls.replaceDomainsIn;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
-
 import org.kiwiproject.jackson.ser.ListToCsvStringDeserializer;
 import org.slf4j.event.Level;
 
-import javax.validation.constraints.NotBlank;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 

--- a/src/main/java/org/kiwiproject/registry/eureka/config/EurekaRegistrationConfig.java
+++ b/src/main/java/org/kiwiproject/registry/eureka/config/EurekaRegistrationConfig.java
@@ -1,10 +1,9 @@
 package org.kiwiproject.registry.eureka.config;
 
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import lombok.Getter;
 import lombok.Setter;
-
-import javax.validation.constraints.Max;
-import javax.validation.constraints.Min;
 
 /**
  * Configuration model needed for registering a service with Eureka

--- a/src/main/java/org/kiwiproject/registry/eureka/server/EurekaHeartbeatSender.java
+++ b/src/main/java/org/kiwiproject/registry/eureka/server/EurekaHeartbeatSender.java
@@ -12,6 +12,7 @@ import static org.kiwiproject.registry.eureka.server.EurekaHeartbeatSender.Failu
 import static org.kiwiproject.registry.eureka.server.EurekaHeartbeatSender.FailureHandlerResult.SELF_HEALING_SUCCEEDED;
 
 import com.google.common.annotations.VisibleForTesting;
+import jakarta.ws.rs.core.Response;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Setter;
@@ -25,7 +26,6 @@ import org.kiwiproject.registry.eureka.common.EurekaUrlProvider;
 import org.kiwiproject.registry.model.ServiceInstance;
 import org.kiwiproject.retry.KiwiRetryerPredicates;
 
-import javax.ws.rs.core.Response;
 import java.time.Duration;
 import java.time.Instant;
 

--- a/src/main/java/org/kiwiproject/registry/eureka/server/EurekaRegistryService.java
+++ b/src/main/java/org/kiwiproject/registry/eureka/server/EurekaRegistryService.java
@@ -1,11 +1,11 @@
 package org.kiwiproject.registry.eureka.server;
 
 import static com.google.common.base.Preconditions.checkState;
+import static jakarta.ws.rs.core.Response.Status.NO_CONTENT;
+import static jakarta.ws.rs.core.Response.Status.OK;
 import static java.time.ZoneOffset.UTC;
 import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
-import static javax.ws.rs.core.Response.Status.NO_CONTENT;
-import static javax.ws.rs.core.Response.Status.OK;
 import static org.kiwiproject.base.KiwiStrings.f;
 import static org.kiwiproject.base.KiwiStrings.format;
 import static org.kiwiproject.collect.KiwiLists.isNotNullOrEmpty;
@@ -14,6 +14,7 @@ import static org.kiwiproject.jaxrs.KiwiResponses.closeQuietly;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import jakarta.ws.rs.core.Response;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
@@ -33,7 +34,6 @@ import org.kiwiproject.registry.model.ServiceInstance.Status;
 import org.kiwiproject.registry.server.RegistryService;
 import org.kiwiproject.retry.SimpleRetryer;
 
-import javax.ws.rs.core.Response;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.TemporalAccessor;

--- a/src/test/java/org/kiwiproject/registry/eureka/client/EurekaRegistryClientTest.java
+++ b/src/test/java/org/kiwiproject/registry/eureka/client/EurekaRegistryClientTest.java
@@ -9,6 +9,10 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import jakarta.ws.rs.ProcessingException;
+import jakarta.ws.rs.ServerErrorException;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -27,11 +31,6 @@ import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
-
-import javax.ws.rs.ProcessingException;
-import javax.ws.rs.ServerErrorException;
-import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.core.Response;
 
 @DisplayName("EurekaRegistryClient")
 @Testcontainers

--- a/src/test/java/org/kiwiproject/registry/eureka/server/EurekaHeartbeatSenderTest.java
+++ b/src/test/java/org/kiwiproject/registry/eureka/server/EurekaHeartbeatSenderTest.java
@@ -14,6 +14,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import jakarta.ws.rs.ProcessingException;
+import jakarta.ws.rs.core.Response;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -30,8 +32,6 @@ import java.net.SocketTimeoutException;
 import java.time.Instant;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
-import javax.ws.rs.ProcessingException;
-import javax.ws.rs.core.Response;
 
 @DisplayName("EurekaHeartbeatSender")
 class EurekaHeartbeatSenderTest {

--- a/src/test/java/org/kiwiproject/registry/eureka/server/EurekaRegistryServiceTest.java
+++ b/src/test/java/org/kiwiproject/registry/eureka/server/EurekaRegistryServiceTest.java
@@ -11,6 +11,8 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import jakarta.ws.rs.core.Response;
+import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -26,14 +28,11 @@ import org.kiwiproject.registry.model.ServicePaths;
 import org.kiwiproject.registry.util.ResponseMock;
 import org.kiwiproject.retry.SimpleRetryer;
 
-import lombok.extern.slf4j.Slf4j;
-
 import java.time.Instant;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
-import javax.ws.rs.core.Response;
 
 /**
  * Unlike the {@link EurekaRegistryServiceIntegrationTest}, this set of tests will mock out the actual calls to Eureka

--- a/src/test/java/org/kiwiproject/registry/eureka/util/EurekaTestDataHelper.java
+++ b/src/test/java/org/kiwiproject/registry/eureka/util/EurekaTestDataHelper.java
@@ -1,10 +1,10 @@
 package org.kiwiproject.registry.eureka.util;
 
+import static jakarta.ws.rs.client.Entity.json;
+import static jakarta.ws.rs.core.HttpHeaders.CONTENT_TYPE;
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON_TYPE;
 import static java.util.concurrent.TimeUnit.MINUTES;
-import static javax.ws.rs.client.Entity.json;
-import static javax.ws.rs.core.HttpHeaders.CONTENT_TYPE;
-import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
-import static javax.ws.rs.core.MediaType.APPLICATION_JSON_TYPE;
 import static org.awaitility.Awaitility.await;
 import static org.kiwiproject.base.KiwiStrings.f;
 import static org.kiwiproject.jaxrs.KiwiResponses.successful;
@@ -18,6 +18,9 @@ import static org.kiwiproject.test.jaxrs.JaxrsTestHelper.assertNoContentResponse
 import static org.kiwiproject.test.jaxrs.JaxrsTestHelper.assertNotFoundResponse;
 import static org.kiwiproject.test.jaxrs.JaxrsTestHelper.assertOkResponse;
 
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.core.Response;
 import lombok.experimental.UtilityClass;
 import lombok.extern.slf4j.Slf4j;
 import org.glassfish.jersey.message.GZipEncoder;
@@ -29,9 +32,6 @@ import org.kiwiproject.registry.util.ServiceInfoHelper;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.images.builder.ImageFromDockerfile;
 
-import javax.ws.rs.client.Client;
-import javax.ws.rs.client.ClientBuilder;
-import javax.ws.rs.core.Response;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;

--- a/src/test/java/org/kiwiproject/registry/util/ResponseMock.java
+++ b/src/test/java/org/kiwiproject/registry/util/ResponseMock.java
@@ -4,12 +4,10 @@ import static org.mockito.AdditionalAnswers.answer;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.spy;
 
-import javax.ws.rs.core.GenericType;
-import javax.ws.rs.core.Response;
-
-import org.mockito.ArgumentMatchers;
-
+import jakarta.ws.rs.core.GenericType;
+import jakarta.ws.rs.core.Response;
 import lombok.experimental.UtilityClass;
+import org.mockito.ArgumentMatchers;
 
 @UtilityClass
 public class ResponseMock {


### PR DESCRIPTION
* Bump version to 2.0.0-SNAPSHOT
* Bump kiwi-parent from 2.0.20 to 3.0.1
* Bump kiwi-bom from 1.1.1 to 2.0.0
* Bump kiwi libraries to next major version
* Update build for JDK 17 and 20
* Update CodeQL workflow to use JDK 17
* Fix Dropwizard package changes
* Refactor from javax to jakarta namespace for Jakarta EE 9