### PR TITLE
Sonar fixes for update to JDK 17

### DIFF
--- a/src/main/java/org/kiwiproject/registry/client/MultiRegistryClient.java
+++ b/src/main/java/org/kiwiproject/registry/client/MultiRegistryClient.java
@@ -1,7 +1,6 @@
 package org.kiwiproject.registry.client;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static java.util.stream.Collectors.toUnmodifiableList;
 import static org.kiwiproject.base.KiwiPreconditions.checkArgumentNotEmpty;
 import static org.kiwiproject.base.KiwiPreconditions.checkArgumentNotNull;
 
@@ -71,7 +70,7 @@ public class MultiRegistryClient implements RegistryClient {
                 .map(registryClient -> registryClient.findAllServiceInstancesBy(query))
                 .filter(KiwiLists::isNotNullOrEmpty)
                 .flatMap(List::stream)
-                .collect(toUnmodifiableList());
+                .toList();
     }
 
     /**
@@ -86,6 +85,6 @@ public class MultiRegistryClient implements RegistryClient {
                 .map(RegistryClient::retrieveAllRegisteredInstances)
                 .filter(KiwiLists::isNotNullOrEmpty)
                 .flatMap(List::stream)
-                .collect(toUnmodifiableList());
+                .toList();
     }
 }

--- a/src/main/java/org/kiwiproject/registry/client/ServiceInstanceFilter.java
+++ b/src/main/java/org/kiwiproject/registry/client/ServiceInstanceFilter.java
@@ -1,6 +1,5 @@
 package org.kiwiproject.registry.client;
 
-import static java.util.stream.Collectors.toList;
 import static org.kiwiproject.base.KiwiPreconditions.checkArgumentNotBlank;
 import static org.kiwiproject.base.KiwiPreconditions.checkArgumentNotNull;
 
@@ -42,7 +41,7 @@ public class ServiceInstanceFilter {
 
         var instancesSatisfyingMinVersion = serviceInstances.stream()
                 .filter(instance -> query.hasNoMinimumVersion() || versionIsAtLeast(instance, query.getMinimumVersion()))
-                .collect(toList());
+                .toList();
 
         if (instancesSatisfyingMinVersion.isEmpty()) {
             LOG.trace("No running instances for service name {} satisfy the minimum version {}",
@@ -52,7 +51,7 @@ public class ServiceInstanceFilter {
 
         var instancesSatisfyingPreferredVersion = instancesSatisfyingMinVersion.stream()
                 .filter(instance -> query.hasNoPreferredVersion() || versionIsExactly(instance, query.getPreferredVersion()))
-                .collect(toList());
+                .toList();
 
         if (instancesSatisfyingPreferredVersion.isEmpty()) {
             LOG.trace("No running instances for service name {} match preferred version {}; finding latest instead",
@@ -112,6 +111,6 @@ public class ServiceInstanceFilter {
 
         return serviceInstances.stream()
                 .filter(instance -> versionIsExactly(instance, maxVersion))
-                .collect(toList());
+                .toList();
     }
 }

--- a/src/main/java/org/kiwiproject/registry/consul/client/ConsulRegistryClient.java
+++ b/src/main/java/org/kiwiproject/registry/consul/client/ConsulRegistryClient.java
@@ -1,6 +1,5 @@
 package org.kiwiproject.registry.consul.client;
 
-import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toMap;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
@@ -66,7 +65,7 @@ public class ConsulRegistryClient implements RegistryClient {
         checkArgumentNotBlank(query.getServiceName(), "The service name cannot be blank");
 
         var services = consul.catalogClient().getService(query.getServiceName()).getResponse();
-        var convertedServices = services.stream().map(this::fromCatalogService).collect(toList());
+        var convertedServices = services.stream().map(this::fromCatalogService).toList();
 
         return ServiceInstanceFilter.filterInstancesByVersion(convertedServices, query);
     }
@@ -147,7 +146,7 @@ public class ConsulRegistryClient implements RegistryClient {
     private void addTagsToMetadata(Map<String, String> metadata, List<String> tags) {
         var filteredTags = tags.stream()
                 .filter(tag -> !TAGS_EXCLUDED.contains(tag))
-                .collect(toList());
+                .toList();
 
         if (isNotNullOrEmpty(filteredTags)) {
             filteredTags.forEach(tag -> {
@@ -186,6 +185,6 @@ public class ConsulRegistryClient implements RegistryClient {
         return consul.catalogClient().getServices().getResponse().keySet().stream()
                 .map(this::findAllServiceInstancesBy)
                 .flatMap(List::stream)
-                .collect(toList());
+                .toList();
     }
 }

--- a/src/main/java/org/kiwiproject/registry/consul/server/ConsulRegistryService.java
+++ b/src/main/java/org/kiwiproject/registry/consul/server/ConsulRegistryService.java
@@ -2,7 +2,6 @@ package org.kiwiproject.registry.consul.server;
 
 import static com.google.common.base.Preconditions.checkState;
 import static java.util.Objects.nonNull;
-import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toMap;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.kiwiproject.base.KiwiStrings.f;
@@ -224,7 +223,7 @@ public class ConsulRegistryService implements RegistryService {
         var metadataAsTags = serviceInstance.getMetadata().entrySet().stream()
                 .filter(entry -> metadataTags.contains(entry.getKey()))
                 .map(entry -> f("{}:{}", entry.getKey(), entry.getValue()))
-                .collect(toList());
+                .toList();
 
         tags.addAll(metadataAsTags);
         return tags;

--- a/src/main/java/org/kiwiproject/registry/eureka/common/EurekaInstance.java
+++ b/src/main/java/org/kiwiproject/registry/eureka/common/EurekaInstance.java
@@ -3,7 +3,6 @@ package org.kiwiproject.registry.eureka.common;
 import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
 import static java.util.stream.Collectors.toMap;
-import static java.util.stream.Collectors.toUnmodifiableList;
 import static org.kiwiproject.collect.KiwiMaps.isNullOrEmpty;
 import static org.kiwiproject.registry.util.Ports.findFirstPortPreferSecure;
 import static org.kiwiproject.registry.util.Ports.findPort;
@@ -176,7 +175,7 @@ public class EurekaInstance {
     private List<Port> portListFromPortsIgnoringNulls(Port... ports) {
         return Arrays.stream(ports)
                 .filter(Objects::nonNull)
-                .collect(toUnmodifiableList());
+                .toList();
     }
 
     private Port buildAdminPortOrNull() {
@@ -199,8 +198,8 @@ public class EurekaInstance {
     }
 
     private boolean isEnabled(Object enabledFlag) {
-        if (enabledFlag instanceof String) {
-            return Boolean.parseBoolean((String) enabledFlag);
+        if (enabledFlag instanceof String s) {
+            return Boolean.parseBoolean(s);
         }
 
         return (boolean) enabledFlag;

--- a/src/main/java/org/kiwiproject/registry/eureka/common/EurekaResponseParser.java
+++ b/src/main/java/org/kiwiproject/registry/eureka/common/EurekaResponseParser.java
@@ -5,7 +5,6 @@ import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.Lists.newArrayList;
 import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
-import static java.util.stream.Collectors.toList;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.kiwiproject.base.KiwiObjects.firstNonNullOrNull;
 import static org.kiwiproject.base.KiwiPreconditions.checkArgumentNotNull;
@@ -58,7 +57,7 @@ public class EurekaResponseParser {
             var instanceList = (List<Map<String, Object>>) instanceOrInstanceList;
             return instanceList.stream()
                     .map(EurekaResponseParser::buildInstance)
-                    .collect(toList());
+                    .toList();
         }
 
         var instance = (Map<String, Object>) instanceOrInstanceList;

--- a/src/test/java/org/kiwiproject/registry/consul/server/ConsulRegistryServiceIntegrationTest.java
+++ b/src/test/java/org/kiwiproject/registry/consul/server/ConsulRegistryServiceIntegrationTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.google.common.net.HostAndPort;
+import lombok.extern.slf4j.Slf4j;
 import org.assertj.core.api.Condition;
 import org.assertj.core.api.SoftAssertions;
 import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
@@ -36,7 +37,6 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ThreadLocalRandom;
-import lombok.extern.slf4j.Slf4j;
 
 @DisplayName("ConsulRegistryService")
 @Testcontainers


### PR DESCRIPTION
Rules fixed:
* java:S6204: "Stream.toList()" method should be used instead of "collectors" when unmodifiable list needed
* java:S6201 - Pattern Matching for "instanceof" operator should be used instead of simple "instanceof" + cast

Even where we are collecting toList(), I replaced these as well, since we really want to be returning immutable (unmodifiable) lists anyway.