### PR TITLE
Sonar cleanup

### DIFF
--- a/src/test/java/org/kiwiproject/registry/client/NoOpRegistryClientTest.java
+++ b/src/test/java/org/kiwiproject/registry/client/NoOpRegistryClientTest.java
@@ -24,7 +24,7 @@ class NoOpRegistryClientTest {
     static void beforeAll() {
         generator = new RandomStringGenerator.Builder()
                 .withinRange('a', 'z')
-                .build();
+                .get();
     }
 
     @BeforeEach

--- a/src/test/java/org/kiwiproject/registry/eureka/config/EurekaConfigTest.java
+++ b/src/test/java/org/kiwiproject/registry/eureka/config/EurekaConfigTest.java
@@ -1,6 +1,5 @@
 package org.kiwiproject.registry.eureka.config;
 
-import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.kiwiproject.collect.KiwiLists.first;
 import static org.kiwiproject.collect.KiwiLists.fourth;
@@ -34,7 +33,7 @@ class EurekaConfigTest {
 
         var uniqueParts = retryIds.stream()
                 .map(EurekaConfigTest::extractRetryIdUniquePart)
-                .collect(toList());
+                .toList();
 
         var firstId = first(uniqueParts);
         assertThat(second(uniqueParts)).isEqualTo(firstId + 1);

--- a/src/test/java/org/kiwiproject/registry/eureka/server/EurekaRegistryServiceIntegrationTest.java
+++ b/src/test/java/org/kiwiproject/registry/eureka/server/EurekaRegistryServiceIntegrationTest.java
@@ -169,7 +169,7 @@ class EurekaRegistryServiceIntegrationTest {
         void shouldRetryLookupAfterRegistrationAndThrowExceptionIfAllTriesExpire() {
             // Going to spy the EurekaClient, so I can fake a bad response from the registry lookup
             var eurekaClientSpy = spy(new EurekaRestClient());
-            var service = new EurekaRegistryService(config, eurekaClientSpy, environment);
+            service = new EurekaRegistryService(config, eurekaClientSpy, environment);
 
             var now = Instant.now();
             when(environment.currentInstant()).thenReturn(now);
@@ -194,7 +194,7 @@ class EurekaRegistryServiceIntegrationTest {
 
             // Going to spy the EurekaClient, so I can fake a bad response from the heartbeat sender
             var eurekaClientSpy = spy(new EurekaRestClient());
-            var service = new EurekaRegistryService(config, eurekaClientSpy, environment);
+            service = new EurekaRegistryService(config, eurekaClientSpy, environment);
 
             var now = Instant.now();
             when(environment.currentInstant()).thenReturn(now);
@@ -251,7 +251,7 @@ class EurekaRegistryServiceIntegrationTest {
 
             // Going to spy the EurekaClient, so I can fake a bad response from the status update sender
             var eurekaClientSpy = spy(new EurekaRestClient());
-            var service = new EurekaRegistryService(config, eurekaClientSpy, environment);
+            service = new EurekaRegistryService(config, eurekaClientSpy, environment);
 
             var serviceInfo = ServiceInfoHelper.buildTestServiceInfoWithHostName("FailStatusChange");
             var serviceInstance = ServiceInstance.fromServiceInfo(serviceInfo)
@@ -291,7 +291,7 @@ class EurekaRegistryServiceIntegrationTest {
         void shouldRetryUnregisterAndThrowExceptionIfAllTriesExpire() {
             // Going to spy the EurekaClient, so I can fake a bad response from the unregistering sender
             var eurekaClientSpy = spy(new EurekaRestClient());
-            var service = new EurekaRegistryService(config, eurekaClientSpy, environment);
+            service = new EurekaRegistryService(config, eurekaClientSpy, environment);
 
             service.registeredInstance.set(EurekaInstance.builder().app("APPID").hostName("FailUnregister").build());
 


### PR DESCRIPTION
* Deprecated code should not be used java:S1874
* "Stream.toList()" method should be used instead of "collectors" when an unmodifiable list is needed java:S6204
* Local variables should not shadow class fields java:S1117