### PR TITLE
Add FakeRegistryClient test utility for stubbing service lookups

### DIFF
--- a/src/main/java/org/kiwiproject/registry/client/FakeRegistryClient.java
+++ b/src/main/java/org/kiwiproject/registry/client/FakeRegistryClient.java
@@ -75,6 +75,7 @@ public class FakeRegistryClient implements RegistryClient {
     /** {@inheritDoc} */
     @Override
     public Optional<ServiceInstance> findServiceInstanceBy(String serviceName, String instanceId) {
+        checkArgumentNotNull(instanceId, "instanceId must not be null");
         return findAllServiceInstancesBy(serviceName).stream()
                 .filter(instance -> instanceId.equals(instance.getInstanceId()))
                 .findFirst();

--- a/src/main/java/org/kiwiproject/registry/client/FakeRegistryClient.java
+++ b/src/main/java/org/kiwiproject/registry/client/FakeRegistryClient.java
@@ -1,5 +1,6 @@
 package org.kiwiproject.registry.client;
 
+import static org.kiwiproject.base.KiwiPreconditions.checkArgumentNotBlank;
 import static org.kiwiproject.base.KiwiPreconditions.checkArgumentNotNull;
 
 import org.kiwiproject.registry.model.ServiceInstance;
@@ -75,7 +76,8 @@ public class FakeRegistryClient implements RegistryClient {
     /** {@inheritDoc} */
     @Override
     public Optional<ServiceInstance> findServiceInstanceBy(String serviceName, String instanceId) {
-        checkArgumentNotNull(instanceId, "instanceId must not be null");
+        checkArgumentNotBlank(serviceName, "serviceName must not be blank");
+        checkArgumentNotBlank(instanceId, "instanceId must not be blank");
         return findAllServiceInstancesBy(serviceName).stream()
                 .filter(instance -> instanceId.equals(instance.getInstanceId()))
                 .findFirst();

--- a/src/main/java/org/kiwiproject/registry/client/FakeRegistryClient.java
+++ b/src/main/java/org/kiwiproject/registry/client/FakeRegistryClient.java
@@ -1,0 +1,109 @@
+package org.kiwiproject.registry.client;
+
+import static org.kiwiproject.base.KiwiPreconditions.checkArgumentNotNull;
+
+import org.kiwiproject.registry.model.ServiceInstance;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * A fake {@link RegistryClient} implementation intended for use in tests. It maintains an in-memory
+ * mapping of service names to {@link ServiceInstance} lists, allowing tests to pre-register instances
+ * and verify lookup behavior without connecting to a real service registry.
+ * <p>
+ * Example usage:
+ * <pre>
+ * var fakeClient = new FakeRegistryClient();
+ * fakeClient.addServiceInstance(ServiceInstance.builder()
+ *         .serviceName("order-service")
+ *         .instanceId("order-1")
+ *         .hostName("localhost")
+ *         .version("1.0.0")
+ *         .build());
+ *
+ * Optional&lt;ServiceInstance&gt; found = fakeClient.findServiceInstanceBy("order-service");
+ * </pre>
+ */
+public class FakeRegistryClient implements RegistryClient {
+
+    private final Map<String, List<ServiceInstance>> serviceInstances;
+
+    /**
+     * Creates an empty {@code FakeRegistryClient} with no pre-registered instances.
+     */
+    public FakeRegistryClient() {
+        this.serviceInstances = new HashMap<>();
+    }
+
+    /**
+     * Creates a {@code FakeRegistryClient} pre-populated with the given instances.
+     *
+     * @param instances the initial list of service instances to register; must not be null
+     */
+    public FakeRegistryClient(List<ServiceInstance> instances) {
+        this();
+        checkArgumentNotNull(instances, "instances must not be null");
+        instances.forEach(this::addServiceInstance);
+    }
+
+    /**
+     * Registers a {@link ServiceInstance} with this client, keyed by its service name.
+     *
+     * @param instance the instance to add; must not be null
+     */
+    public void addServiceInstance(ServiceInstance instance) {
+        checkArgumentNotNull(instance, "instance must not be null");
+        serviceInstances
+                .computeIfAbsent(instance.getServiceName(), k -> new ArrayList<>())
+                .add(instance);
+    }
+
+    /**
+     * Registers multiple {@link ServiceInstance} objects with this client.
+     *
+     * @param instances the instances to add; must not be null
+     */
+    public void addServiceInstances(List<ServiceInstance> instances) {
+        checkArgumentNotNull(instances, "instances must not be null");
+        instances.forEach(this::addServiceInstance);
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Finds the instance matching both service name and instance ID, or returns empty if not found.
+     */
+    @Override
+    public Optional<ServiceInstance> findServiceInstanceBy(String serviceName, String instanceId) {
+        return findAllServiceInstancesBy(serviceName).stream()
+                .filter(instance -> instanceId.equals(instance.getInstanceId()))
+                .findFirst();
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Returns all instances matching the query's service name, filtered by version predicates if present.
+     */
+    @Override
+    public List<ServiceInstance> findAllServiceInstancesBy(InstanceQuery query) {
+        var instances = serviceInstances.getOrDefault(query.getServiceName(), List.of());
+        return ServiceInstanceFilter.filterInstancesByVersion(instances, query);
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Returns all registered instances across all service names.
+     */
+    @Override
+    public List<ServiceInstance> retrieveAllRegisteredInstances() {
+        return serviceInstances.values().stream()
+                .flatMap(List::stream)
+                .toList();
+    }
+}

--- a/src/main/java/org/kiwiproject/registry/client/FakeRegistryClient.java
+++ b/src/main/java/org/kiwiproject/registry/client/FakeRegistryClient.java
@@ -72,11 +72,7 @@ public class FakeRegistryClient implements RegistryClient {
         instances.forEach(this::addServiceInstance);
     }
 
-    /**
-     * {@inheritDoc}
-     * <p>
-     * Finds the instance matching both service name and instance ID, or returns empty if not found.
-     */
+    /** {@inheritDoc} */
     @Override
     public Optional<ServiceInstance> findServiceInstanceBy(String serviceName, String instanceId) {
         return findAllServiceInstancesBy(serviceName).stream()
@@ -84,22 +80,14 @@ public class FakeRegistryClient implements RegistryClient {
                 .findFirst();
     }
 
-    /**
-     * {@inheritDoc}
-     * <p>
-     * Returns all instances matching the query's service name, filtered by version predicates if present.
-     */
+    /** {@inheritDoc} */
     @Override
     public List<ServiceInstance> findAllServiceInstancesBy(InstanceQuery query) {
         var instances = serviceInstances.getOrDefault(query.getServiceName(), List.of());
         return ServiceInstanceFilter.filterInstancesByVersion(instances, query);
     }
 
-    /**
-     * {@inheritDoc}
-     * <p>
-     * Returns all registered instances across all service names.
-     */
+    /** {@inheritDoc} */
     @Override
     public List<ServiceInstance> retrieveAllRegisteredInstances() {
         return serviceInstances.values().stream()

--- a/src/test/java/org/kiwiproject/registry/client/FakeRegistryClientTest.java
+++ b/src/test/java/org/kiwiproject/registry/client/FakeRegistryClientTest.java
@@ -1,0 +1,263 @@
+package org.kiwiproject.registry.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.kiwiproject.collect.KiwiLists.first;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.kiwiproject.registry.client.RegistryClient.InstanceQuery;
+import org.kiwiproject.registry.model.Port;
+import org.kiwiproject.registry.model.Port.PortType;
+import org.kiwiproject.registry.model.Port.Security;
+import org.kiwiproject.registry.model.ServiceInstance;
+import org.kiwiproject.registry.model.ServiceInstance.Status;
+import org.kiwiproject.registry.model.ServicePaths;
+
+import java.util.List;
+
+@DisplayName("FakeRegistryClient")
+class FakeRegistryClientTest {
+
+    private FakeRegistryClient fakeClient;
+
+    @BeforeEach
+    void setUp() {
+        fakeClient = new FakeRegistryClient();
+    }
+
+    @Nested
+    class Constructors {
+
+        @Test
+        void defaultConstructor_shouldCreateEmptyClient() {
+            assertThat(fakeClient.retrieveAllRegisteredInstances()).isEmpty();
+        }
+
+        @Test
+        void listConstructor_shouldPrePopulateInstances() {
+            var instance1 = newServiceInstance("order-service", "host-1", "1.0.0");
+            var instance2 = newServiceInstance("invoice-service", "host-2", "2.0.0");
+
+            var client = new FakeRegistryClient(List.of(instance1, instance2));
+
+            assertThat(client.retrieveAllRegisteredInstances())
+                    .containsExactlyInAnyOrder(instance1, instance2);
+        }
+
+        @Test
+        void listConstructor_shouldRejectNullList() {
+            assertThatIllegalArgumentException()
+                    .isThrownBy(() -> new FakeRegistryClient(null))
+                    .withMessage("instances must not be null");
+        }
+    }
+
+    @Nested
+    class AddServiceInstance {
+
+        @Test
+        void shouldAddSingleInstance() {
+            var instance = newServiceInstance("order-service", "host-1", "1.0.0");
+            fakeClient.addServiceInstance(instance);
+
+            assertThat(fakeClient.findAllServiceInstancesBy("order-service")).containsExactly(instance);
+        }
+
+        @Test
+        void shouldAddMultipleInstancesForSameService() {
+            var instance1 = newServiceInstance("order-service", "host-1", "1.0.0");
+            var instance2 = newServiceInstance("order-service", "host-2", "1.0.0");
+            fakeClient.addServiceInstance(instance1);
+            fakeClient.addServiceInstance(instance2);
+
+            assertThat(fakeClient.findAllServiceInstancesBy("order-service"))
+                    .containsExactly(instance1, instance2);
+        }
+
+        @Test
+        void shouldRejectNullInstance() {
+            assertThatIllegalArgumentException()
+                    .isThrownBy(() -> fakeClient.addServiceInstance(null))
+                    .withMessage("instance must not be null");
+        }
+    }
+
+    @Nested
+    class AddServiceInstances {
+
+        @Test
+        void shouldAddAllInstances() {
+            var instance1 = newServiceInstance("order-service", "host-1", "1.0.0");
+            var instance2 = newServiceInstance("invoice-service", "host-2", "2.0.0");
+            fakeClient.addServiceInstances(List.of(instance1, instance2));
+
+            assertThat(fakeClient.retrieveAllRegisteredInstances())
+                    .containsExactlyInAnyOrder(instance1, instance2);
+        }
+
+        @Test
+        void shouldRejectNullList() {
+            assertThatIllegalArgumentException()
+                    .isThrownBy(() -> fakeClient.addServiceInstances(null))
+                    .withMessage("instances must not be null");
+        }
+    }
+
+    @Nested
+    class FindServiceInstanceByNameAndId {
+
+        @Test
+        void shouldReturnInstance_WhenServiceNameAndIdMatch() {
+            var instance = newServiceInstance("order-service", "host-1", "1.0.0", "instance-42");
+            fakeClient.addServiceInstance(instance);
+
+            assertThat(fakeClient.findServiceInstanceBy("order-service", "instance-42"))
+                    .contains(instance);
+        }
+
+        @Test
+        void shouldReturnEmpty_WhenServiceNameDoesNotMatch() {
+            fakeClient.addServiceInstance(newServiceInstance("order-service", "host-1", "1.0.0", "instance-42"));
+
+            assertThat(fakeClient.findServiceInstanceBy("unknown-service", "instance-42")).isEmpty();
+        }
+
+        @Test
+        void shouldReturnEmpty_WhenInstanceIdDoesNotMatch() {
+            fakeClient.addServiceInstance(newServiceInstance("order-service", "host-1", "1.0.0", "instance-42"));
+
+            assertThat(fakeClient.findServiceInstanceBy("order-service", "wrong-id")).isEmpty();
+        }
+
+        @Test
+        void shouldReturnEmpty_WhenNoInstancesRegistered() {
+            assertThat(fakeClient.findServiceInstanceBy("order-service", "instance-1")).isEmpty();
+        }
+    }
+
+    @Nested
+    class FindServiceInstanceByName {
+
+        @Test
+        void shouldReturnAnInstance_WhenServiceNameMatches() {
+            var instance = newServiceInstance("order-service", "host-1", "1.0.0");
+            fakeClient.addServiceInstance(instance);
+
+            assertThat(fakeClient.findServiceInstanceBy("order-service")).contains(instance);
+        }
+
+        @Test
+        void shouldReturnEmpty_WhenServiceNameDoesNotMatch() {
+            fakeClient.addServiceInstance(newServiceInstance("order-service", "host-1", "1.0.0"));
+
+            assertThat(fakeClient.findServiceInstanceBy("unknown-service")).isEmpty();
+        }
+
+        @Test
+        void shouldReturnEmpty_WhenNoInstancesRegistered() {
+            assertThat(fakeClient.findServiceInstanceBy("order-service")).isEmpty();
+        }
+    }
+
+    @Nested
+    class FindAllServiceInstancesByQuery {
+
+        @Test
+        void shouldReturnAllMatchingInstances_WhenNoVersionPredicates() {
+            var instance1 = newServiceInstance("order-service", "host-1", "1.0.0");
+            var instance2 = newServiceInstance("order-service", "host-2", "2.0.0");
+            fakeClient.addServiceInstances(List.of(instance1, instance2));
+
+            var query = InstanceQuery.builder().serviceName("order-service").build();
+            assertThat(fakeClient.findAllServiceInstancesBy(query))
+                    .containsExactly(instance1, instance2);
+        }
+
+        @Test
+        void shouldReturnEmpty_WhenServiceNotRegistered() {
+            var query = InstanceQuery.builder().serviceName("unknown-service").build();
+            assertThat(fakeClient.findAllServiceInstancesBy(query)).isEmpty();
+        }
+
+        @Test
+        void shouldFilterByMinimumVersion() {
+            var v1Instance = newServiceInstance("order-service", "host-1", "1.0.0");
+            var v2Instance = newServiceInstance("order-service", "host-2", "2.0.0");
+            fakeClient.addServiceInstances(List.of(v1Instance, v2Instance));
+
+            var query = InstanceQuery.builder()
+                    .serviceName("order-service")
+                    .minimumVersion("1.5.0")
+                    .build();
+
+            assertThat(fakeClient.findAllServiceInstancesBy(query)).containsExactly(v2Instance);
+        }
+
+        @Test
+        void shouldFilterByPreferredVersion() {
+            var v1Instance = newServiceInstance("order-service", "host-1", "1.0.0");
+            var v2Instance = newServiceInstance("order-service", "host-2", "2.0.0");
+            fakeClient.addServiceInstances(List.of(v1Instance, v2Instance));
+
+            var query = InstanceQuery.builder()
+                    .serviceName("order-service")
+                    .preferredVersion("1.0.0")
+                    .build();
+
+            assertThat(fakeClient.findAllServiceInstancesBy(query)).containsExactly(v1Instance);
+        }
+
+        @Test
+        void shouldNotReturnInstancesFromOtherServices() {
+            fakeClient.addServiceInstance(newServiceInstance("order-service", "host-1", "1.0.0"));
+            fakeClient.addServiceInstance(newServiceInstance("invoice-service", "host-2", "1.0.0"));
+
+            var query = InstanceQuery.builder().serviceName("order-service").build();
+            var results = fakeClient.findAllServiceInstancesBy(query);
+
+            assertThat(results).hasSize(1);
+            assertThat(first(results).getServiceName()).isEqualTo("order-service");
+        }
+    }
+
+    @Nested
+    class RetrieveAllRegisteredInstances {
+
+        @Test
+        void shouldReturnAllInstancesAcrossAllServices() {
+            var instance1 = newServiceInstance("order-service", "host-1", "1.0.0");
+            var instance2 = newServiceInstance("order-service", "host-2", "1.0.0");
+            var instance3 = newServiceInstance("invoice-service", "host-3", "2.0.0");
+            fakeClient.addServiceInstances(List.of(instance1, instance2, instance3));
+
+            assertThat(fakeClient.retrieveAllRegisteredInstances())
+                    .containsExactlyInAnyOrder(instance1, instance2, instance3);
+        }
+
+        @Test
+        void shouldReturnEmptyList_WhenNoInstancesRegistered() {
+            assertThat(fakeClient.retrieveAllRegisteredInstances()).isEmpty();
+        }
+    }
+
+    private static ServiceInstance newServiceInstance(String serviceName, String hostName, String version) {
+        return newServiceInstance(serviceName, hostName, version, null);
+    }
+
+    private static ServiceInstance newServiceInstance(String serviceName, String hostName, String version,
+                                                       String instanceId) {
+        return ServiceInstance.builder()
+                .serviceName(serviceName)
+                .hostName(hostName)
+                .ip("127.0.0.1")
+                .instanceId(instanceId)
+                .version(version)
+                .status(Status.UP)
+                .ports(List.of(Port.of(8080, PortType.APPLICATION, Security.NOT_SECURE)))
+                .paths(ServicePaths.builder().build())
+                .build();
+    }
+}

--- a/src/test/java/org/kiwiproject/registry/client/FakeRegistryClientTest.java
+++ b/src/test/java/org/kiwiproject/registry/client/FakeRegistryClientTest.java
@@ -136,6 +136,13 @@ class FakeRegistryClientTest {
         void shouldReturnEmpty_WhenNoInstancesRegistered() {
             assertThat(fakeClient.findServiceInstanceBy("order-service", "instance-1")).isEmpty();
         }
+
+        @Test
+        void shouldRejectNullInstanceId() {
+            assertThatIllegalArgumentException()
+                    .isThrownBy(() -> fakeClient.findServiceInstanceBy("order-service", null))
+                    .withMessage("instanceId must not be null");
+        }
     }
 
     @Nested

--- a/src/test/java/org/kiwiproject/registry/client/FakeRegistryClientTest.java
+++ b/src/test/java/org/kiwiproject/registry/client/FakeRegistryClientTest.java
@@ -142,7 +142,7 @@ class FakeRegistryClientTest {
 
         @ParameterizedTest
         @NullAndEmptySource
-        @ValueSource(strings = {" ", "  "})
+        @ValueSource(strings = {" ", "\t", "\n"})
         void shouldRejectBlankServiceName(String serviceName) {
             assertThatIllegalArgumentException()
                     .isThrownBy(() -> fakeClient.findServiceInstanceBy(serviceName, "instance-1"))
@@ -151,7 +151,7 @@ class FakeRegistryClientTest {
 
         @ParameterizedTest
         @NullAndEmptySource
-        @ValueSource(strings = {" ", "  "})
+        @ValueSource(strings = {" ", "\t", "\n"})
         void shouldRejectBlankInstanceId(String instanceId) {
             assertThatIllegalArgumentException()
                     .isThrownBy(() -> fakeClient.findServiceInstanceBy("order-service", instanceId))

--- a/src/test/java/org/kiwiproject/registry/client/FakeRegistryClientTest.java
+++ b/src/test/java/org/kiwiproject/registry/client/FakeRegistryClientTest.java
@@ -8,6 +8,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.kiwiproject.registry.client.RegistryClient.InstanceQuery;
 import org.kiwiproject.registry.model.Port;
 import org.kiwiproject.registry.model.Port.PortType;
@@ -137,11 +140,22 @@ class FakeRegistryClientTest {
             assertThat(fakeClient.findServiceInstanceBy("order-service", "instance-1")).isEmpty();
         }
 
-        @Test
-        void shouldRejectNullInstanceId() {
+        @ParameterizedTest
+        @NullAndEmptySource
+        @ValueSource(strings = {" ", "  "})
+        void shouldRejectBlankServiceName(String serviceName) {
             assertThatIllegalArgumentException()
-                    .isThrownBy(() -> fakeClient.findServiceInstanceBy("order-service", null))
-                    .withMessage("instanceId must not be null");
+                    .isThrownBy(() -> fakeClient.findServiceInstanceBy(serviceName, "instance-1"))
+                    .withMessage("serviceName must not be blank");
+        }
+
+        @ParameterizedTest
+        @NullAndEmptySource
+        @ValueSource(strings = {" ", "  "})
+        void shouldRejectBlankInstanceId(String instanceId) {
+            assertThatIllegalArgumentException()
+                    .isThrownBy(() -> fakeClient.findServiceInstanceBy("order-service", instanceId))
+                    .withMessage("instanceId must not be blank");
         }
     }
 

--- a/src/test/java/org/kiwiproject/registry/client/FakeRegistryClientTest.java
+++ b/src/test/java/org/kiwiproject/registry/client/FakeRegistryClientTest.java
@@ -268,7 +268,9 @@ class FakeRegistryClientTest {
         return newServiceInstance(serviceName, hostName, version, null);
     }
 
-    private static ServiceInstance newServiceInstance(String serviceName, String hostName, String version,
+    private static ServiceInstance newServiceInstance(String serviceName,
+                                                       String hostName,
+                                                       String version,
                                                        String instanceId) {
         return ServiceInstance.builder()
                 .serviceName(serviceName)


### PR DESCRIPTION
- Adds FakeRegistryClient to org.kiwiproject.registry.client alongside NoOpRegistryClient and MultiRegistryClient
- Maintains an in-memory Map<String, List<ServiceInstance>> keyed by service name; no test-framework dependencies so it ships in main sources
- Supports pre-populating instances at construction time or incrementally via addServiceInstance or addServiceInstances; delegates version filtering to the existing ServiceInstanceFilter

Closes #532 

---
_Generated by [Claude Code](https://claude.ai/code/)_